### PR TITLE
Unify product display UI across feed, profile, and search

### DIFF
--- a/artifacts/web-app/index.html
+++ b/artifacts/web-app/index.html
@@ -14,7 +14,6 @@
       --primary:#3f6df6;
       --primary-2:#dfe7ff;
       --chip:#f9f7f3;
-      --success:#dff0e7;
       --danger:#ffe2e2;
       --shadow:0 8px 24px rgba(0,0,0,.06);
       --radius:24px;
@@ -39,11 +38,9 @@
     .category-card.active{outline:2px solid #ccd8ff;background:#f8faff}
     .category-icon{width:52px;height:52px;border-radius:18px;background:#f4efe8;display:flex;align-items:center;justify-content:center;margin:0 auto 10px;font-size:26px}
     .category-name{font-size:15px;font-weight:800}
-    .grid{display:grid;grid-template-columns:1fr 1fr;gap:14px}
     .btn-row{display:flex;gap:10px}
     .btn{border:none;border-radius:18px;padding:14px 16px;font-weight:800;font-size:16px;cursor:pointer}
     .btn.primary{background:linear-gradient(180deg,#5881ff,#3262f0);color:#fff;flex:1}
-    .btn.soft{background:var(--success);color:#2a7250;flex:1}
     .btn.ghost{background:#fff;border:1px solid var(--line)}
     .feed-list{display:flex;flex-direction:column;gap:16px}
     .feed-card{background:#fff;border-radius:30px;padding:14px;box-shadow:var(--shadow);border:1px solid var(--line)}

--- a/artifacts/web-app/index.html
+++ b/artifacts/web-app/index.html
@@ -40,13 +40,6 @@
     .category-icon{width:52px;height:52px;border-radius:18px;background:#f4efe8;display:flex;align-items:center;justify-content:center;margin:0 auto 10px;font-size:26px}
     .category-name{font-size:15px;font-weight:800}
     .grid{display:grid;grid-template-columns:1fr 1fr;gap:14px}
-    .product-card{background:#fff;border:1px solid var(--line);border-radius:28px;padding:14px;box-shadow:var(--shadow)}
-    .image-box{position:relative;border-radius:22px;background:linear-gradient(135deg,#dcdcdc,#f7f7f7);aspect-ratio:1/1;overflow:hidden;display:flex;align-items:center;justify-content:center;font-size:44px;color:#999}
-    .badge{position:absolute;top:10px;left:10px;background:#fff;border-radius:12px;padding:6px 10px;font-size:12px;font-weight:800}
-    .badge.right{left:auto;right:10px;background:rgba(24,24,24,.78);color:#fff}
-    .product-title{font-size:18px;font-weight:800;line-height:1.15;margin:12px 0 8px}
-    .product-meta{font-size:14px;color:var(--muted);margin-bottom:14px}
-    .price{font-size:18px;font-weight:900;color:var(--primary);margin:6px 0}
     .btn-row{display:flex;gap:10px}
     .btn{border:none;border-radius:18px;padding:14px 16px;font-weight:800;font-size:16px;cursor:pointer}
     .btn.primary{background:linear-gradient(180deg,#5881ff,#3262f0);color:#fff;flex:1}
@@ -144,7 +137,7 @@
     <div class="section-label">หมวดหมู่</div>
     <div class="category-row" id="categoryRow"></div>
     <div id="shopNotice"></div>
-    <div id="shopGrid" class="grid"></div>
+    <div id="shopGrid" class="feed-list"></div>
   </section>
 
   <section id="page-add" class="page">
@@ -208,7 +201,7 @@
       <div class="muted" id="profileEmail">-</div>
     </div>
     <div class="section-label">สินค้าของฉัน</div>
-    <div id="profileGrid" class="grid"></div>
+    <div id="profileGrid" class="feed-list"></div>
   </section>
 </div>
 

--- a/artifacts/web-app/src/ui/cards.js
+++ b/artifacts/web-app/src/ui/cards.js
@@ -3,29 +3,6 @@ import { state } from "../state.js";
 import { offers } from "../api.js";
 import { authGuard } from "./nav.js";
 
-export function productCardHtml(item) {
-  const buyBtn =
-    item.dealType === "swap"
-      ? ""
-      : `<button class="btn soft" data-buy-now="1">ซื้อเลย</button>`;
-  const priceLabel =
-    item.dealType === "swap"
-      ? "เปิดรับ Xwap"
-      : `฿${Number(item.priceCash || 0).toLocaleString()}`;
-  return `
-    <div class="product-card" data-item-id="${escapeHtml(item.id)}" data-item-title="${escapeHtml(item.title || "")}" data-owner-id="${escapeHtml(item.ownerId)}">
-      <div class="image-box">
-        <div class="badge">${escapeHtml(item.conditionLabel || "สภาพดี")}</div>
-        <div class="badge right">${item.dealType === "swap" ? "แลกได้" : item.dealType === "both" ? "ขาย/แลก" : "ซื้อได้"}</div>
-        ${escapeHtml(itemEmoji(item))}
-      </div>
-      <div class="product-title">${escapeHtml(item.title || "-")}</div>
-      <div class="price">${escapeHtml(priceLabel)}</div>
-      <div class="product-meta">${escapeHtml(item.locationLabel || "Bangkok")} · ${escapeHtml(item.category || "")}</div>
-      <div class="btn-row">${buyBtn}<button class="btn primary" data-xwap="1">Xwap</button></div>
-    </div>`;
-}
-
 export function feedCardHtml(item) {
   return `
     <div class="feed-card" data-item-id="${escapeHtml(item.id)}" data-item-title="${escapeHtml(item.title || "")}" data-owner-id="${escapeHtml(item.ownerId)}">
@@ -56,11 +33,6 @@ export function bindCardActions(container) {
         card.getAttribute("data-owner-id"),
       );
     });
-  });
-  container.querySelectorAll("[data-buy-now]").forEach((btn) => {
-    btn.addEventListener("click", () =>
-      alert("เวอร์ชันนี้ยังไม่ได้ต่อ Buy flow"),
-    );
   });
 }
 

--- a/artifacts/web-app/src/ui/profile.js
+++ b/artifacts/web-app/src/ui/profile.js
@@ -2,7 +2,7 @@ import { qs, notify } from "../util.js";
 import { state } from "../state.js";
 import { items, profiles } from "../api.js";
 import { authGuard } from "./nav.js";
-import { productCardHtml, bindCardActions } from "./cards.js";
+import { feedCardHtml, bindCardActions } from "./cards.js";
 
 export async function loadProfile() {
   if (!authGuard()) return;
@@ -16,8 +16,8 @@ export async function loadProfile() {
     const { items: mine } = await items.list({ owner_id: me.id });
     const grid = qs("profileGrid");
     grid.innerHTML = mine.length
-      ? mine.map(productCardHtml).join("")
-      : `<div class="empty" style="grid-column:1/-1">ยังไม่มีสินค้าของคุณ</div>`;
+      ? mine.map(feedCardHtml).join("")
+      : `<div class="empty">ยังไม่มีสินค้าของคุณ</div>`;
     bindCardActions(grid);
   } catch (e) {
     notify("profileNotice", "error", String(e?.message || e));

--- a/artifacts/web-app/src/ui/shop.js
+++ b/artifacts/web-app/src/ui/shop.js
@@ -2,9 +2,9 @@ import { qs, notify } from "../util.js";
 import { state, categories } from "../state.js";
 import { items } from "../api.js";
 import { authGuard } from "./nav.js";
-import { productCardHtml, bindCardActions } from "./cards.js";
+import { feedCardHtml, bindCardActions } from "./cards.js";
 
-export { productCardHtml };
+export { feedCardHtml };
 
 export function renderCategories() {
   const row = qs("categoryRow");
@@ -51,8 +51,8 @@ export async function loadShop() {
     const { items: list } = await items.list(params);
     const grid = qs("shopGrid");
     grid.innerHTML = list.length
-      ? list.map(productCardHtml).join("")
-      : `<div class="empty" style="grid-column:1/-1">ยังไม่มีสินค้า</div>`;
+      ? list.map(feedCardHtml).join("")
+      : `<div class="empty">ยังไม่มีสินค้า</div>`;
     bindCardActions(grid);
   } catch (e) {
     notify("shopNotice", "error", String(e?.message || e));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep feed product card layout unchanged (left item / right wanted item swap layout)
- switch profile product rendering to use the same feed swap card layout
- switch shop/search product rendering to use the same feed swap card layout
- remove the unused alternate product-card template and legacy styles so only one product card type remains

## Scope Guardrails
- no business logic changes
- no backend/chat/other module changes
- UI consistency only for product display

## Walkthrough
[feed_profile_shop_swap_layout_consistency.mp4](https://cursor.com/agents/bc-159311e1-004c-47c6-9027-7f2753bc5ea9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeed_profile_shop_swap_layout_consistency.mp4)
[Profile swap card consistency](https://cursor.com/agents/bc-159311e1-004c-47c6-9027-7f2753bc5ea9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fproduct_card_ui_consistency_profile.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-159311e1-004c-47c6-9027-7f2753bc5ea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-159311e1-004c-47c6-9027-7f2753bc5ea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

