### PR TITLE
Rebuild feed to match QXwap reference swap-card behavior

### DIFF
--- a/artifacts/web-app/index.html
+++ b/artifacts/web-app/index.html
@@ -52,16 +52,311 @@
     .btn.primary{background:linear-gradient(180deg,#5881ff,#3262f0);color:#fff;flex:1}
     .btn.soft{background:var(--success);color:#2a7250;flex:1}
     .btn.ghost{background:#fff;border:1px solid var(--line)}
+    body.modal-open{overflow:hidden}
+    #page-feed{padding-top:16px}
+    .feed-top-sticky{
+      position:sticky;
+      top:0;
+      z-index:30;
+      background:linear-gradient(180deg,rgba(245,243,239,.98) 78%,rgba(245,243,239,0));
+      backdrop-filter:blur(6px);
+      margin:0 -16px 12px;
+      padding:0 16px 8px;
+    }
+    #page-feed .search-row{margin:10px 0 12px}
+    #page-feed .chips{margin:0 0 12px}
+    .feed-category-row{display:flex;gap:10px;overflow:auto;padding:0 0 8px}
+    .feed-category-chip{
+      border:1px solid var(--line);
+      background:#fff;
+      border-radius:999px;
+      min-height:40px;
+      padding:8px 14px;
+      font-size:13px;
+      font-weight:800;
+      color:#4d4740;
+      display:inline-flex;
+      align-items:center;
+      gap:8px;
+      white-space:nowrap;
+      cursor:pointer;
+      box-shadow:0 6px 14px rgba(0,0,0,.04);
+    }
+    .feed-category-chip.active{
+      background:#eff3ff;
+      border-color:#c9d6ff;
+      color:#1f3ea5;
+    }
+    .feed-category-icon{font-size:16px;line-height:1}
     .feed-list{display:flex;flex-direction:column;gap:16px}
-    .feed-card{background:#fff;border-radius:30px;padding:14px;box-shadow:var(--shadow);border:1px solid var(--line)}
-    .swap-panels{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:12px}
-    .swap-panel{position:relative;background:#f8f7f4;border-radius:24px;padding:12px;min-height:240px}
-    .swap-label{position:absolute;top:10px;left:10px;background:#fff;border-radius:999px;padding:6px 10px;font-size:12px;font-weight:900}
-    .swap-label.right{left:auto;right:10px;background:#161616;color:#fff}
-    .swap-image{margin-top:34px;border-radius:18px;background:linear-gradient(135deg,#dcdcdc,#f7f7f7);aspect-ratio:1/1;display:flex;align-items:center;justify-content:center;font-size:42px;color:#9a9a9a}
-    .want-box{margin-top:34px;border-radius:18px;background:#fff;min-height:calc(100% - 34px);padding:18px;display:flex;flex-direction:column;justify-content:center;border:1px dashed #d9d9d9}
-    .swap-card-title{font-size:18px;font-weight:900;margin:8px 0 4px}
-    .swap-card-sub{font-size:14px;color:var(--muted)}
+    .feed-card{
+      position:relative;
+      background:#fff;
+      border-radius:32px;
+      padding:12px 12px 16px;
+      box-shadow:0 16px 30px rgba(24,22,17,.08);
+      border:1px solid #ebe5db;
+      overflow:hidden;
+      transition:transform .22s ease,box-shadow .22s ease,border-color .2s ease;
+    }
+    .feed-card.saved{border-color:#ffd082}
+    .feed-card.save-bump{transform:translateY(-2px)}
+    .feed-card.xwap-active{box-shadow:0 20px 34px rgba(63,109,246,.2)}
+    .feed-card.swiped-left,.feed-card.swiped-right{transform:scale(.985)}
+    .feed-card.swiped-left{box-shadow:0 12px 30px rgba(243,107,74,.2)}
+    .feed-card.swiped-right{box-shadow:0 12px 30px rgba(57,132,229,.2)}
+    .feed-save-btn{
+      position:absolute;
+      top:16px;
+      right:16px;
+      z-index:4;
+      border:none;
+      width:40px;
+      height:40px;
+      border-radius:50%;
+      background:rgba(255,255,255,.92);
+      box-shadow:0 10px 18px rgba(0,0,0,.12);
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      font-size:22px;
+      color:#484038;
+      cursor:pointer;
+      transition:transform .18s ease,background .18s ease,color .18s ease;
+    }
+    .feed-save-btn.saved{background:#151515;color:#ffd46f}
+    .feed-save-btn:active{transform:scale(.94)}
+    .swap-hero{
+      position:relative;
+      display:grid;
+      grid-template-columns:1fr 1fr;
+      gap:8px;
+      min-height:222px;
+      margin-bottom:14px;
+    }
+    .swap-half{
+      position:relative;
+      border-radius:24px;
+      overflow:hidden;
+      background:#f6f3ee;
+      border:1px solid #ece6db;
+      min-height:222px;
+      padding:10px;
+    }
+    .swap-half.want{background:#f9f8f4}
+    .swap-label{
+      position:absolute;
+      top:10px;
+      left:10px;
+      z-index:2;
+      background:rgba(255,255,255,.95);
+      border-radius:999px;
+      padding:5px 10px;
+      font-size:12px;
+      font-weight:900;
+    }
+    .swap-label.right{left:auto;right:10px;background:rgba(21,21,21,.9);color:#fff}
+    .swap-media{
+      margin-top:28px;
+      height:calc(100% - 28px);
+      border-radius:16px;
+      overflow:hidden;
+      background:linear-gradient(135deg,#e5e0d8,#f7f6f2);
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      text-align:center;
+    }
+    .swap-media img{
+      width:100%;
+      height:100%;
+      object-fit:cover;
+      display:block;
+      background:#f1eee8;
+    }
+    .swap-media-fallback{
+      font-size:60px;
+      line-height:1;
+      color:#888276;
+      user-select:none;
+    }
+    .swap-media-wanted{
+      font-size:14px;
+      font-weight:800;
+      line-height:1.45;
+      color:#3b352e;
+      padding:12px;
+    }
+    .feed-xwap-cta{
+      position:absolute;
+      left:50%;
+      top:50%;
+      transform:translate(-50%,-50%);
+      z-index:5;
+      border:none;
+      min-width:94px;
+      height:44px;
+      padding:0 20px;
+      border-radius:999px;
+      background:linear-gradient(180deg,#5881ff,#3262f0);
+      color:#fff;
+      font-size:15px;
+      font-weight:900;
+      box-shadow:0 14px 22px rgba(50,98,240,.35);
+      cursor:pointer;
+    }
+    .feed-xwap-cta:active{transform:translate(-50%,-50%) scale(.96)}
+    .feed-card-body{padding:0 4px}
+    .swap-card-title{font-size:20px;font-weight:900;letter-spacing:-.02em;margin:2px 0 4px;line-height:1.2}
+    .swap-card-sub{font-size:13px;color:var(--muted)}
+    .feed-meta-row{
+      display:flex;
+      justify-content:space-between;
+      align-items:flex-end;
+      gap:10px;
+      margin-top:10px;
+    }
+    .feed-price{font-size:19px;font-weight:900;color:var(--primary)}
+    .feed-request-summary{
+      font-size:12px;
+      color:#756f66;
+      text-align:right;
+      max-width:56%;
+      line-height:1.3;
+    }
+    .feed-request-preview{
+      display:flex;
+      align-items:center;
+      gap:10px;
+      margin-top:10px;
+      padding:9px 10px;
+      border-radius:14px;
+      background:#f8f5ef;
+      border:1px solid #efe7db;
+    }
+    .feed-request-avatars{display:flex;align-items:center}
+    .feed-request-avatar{
+      width:24px;
+      height:24px;
+      border-radius:50%;
+      margin-left:-6px;
+      border:2px solid #fff;
+      background:#d4ccbf;
+      color:#312c25;
+      font-size:11px;
+      font-weight:900;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      overflow:hidden;
+    }
+    .feed-request-avatar:first-child{margin-left:0}
+    .feed-request-avatar.fallback{background:#e7dfd2}
+    .feed-request-avatar img{width:100%;height:100%;object-fit:cover;display:block}
+    .feed-request-text{font-size:12px;color:#635b52;font-weight:700;line-height:1.3}
+    .feed-actions{display:flex;gap:10px;margin-top:12px}
+    .feed-actions .btn{flex:1}
+    .skeleton-card{pointer-events:none}
+    .skeleton-block,.skeleton-line{
+      position:relative;
+      overflow:hidden;
+      background:#efebe4;
+    }
+    .skeleton-block::after,.skeleton-line::after{
+      content:"";
+      position:absolute;
+      inset:0;
+      background:linear-gradient(90deg,transparent,rgba(255,255,255,.7),transparent);
+      animation:skeleton-wave 1.2s infinite;
+      transform:translateX(-100%);
+    }
+    .skeleton-block{border-radius:14px;min-height:160px}
+    .skeleton-line{height:14px;border-radius:10px;margin:10px 0}
+    .skeleton-line.w-70{width:70%}
+    .skeleton-line.w-55{width:55%}
+    .skeleton-line.w-85{width:85%}
+    @keyframes skeleton-wave{100%{transform:translateX(100%)}}
+    .feed-empty-state,.feed-fallback-state{margin-bottom:12px}
+    .feed-empty-title{font-size:16px;font-weight:900}
+    .feed-empty-sub{font-size:13px;color:#786f65;margin-top:4px}
+    .feed-detail-modal{
+      position:fixed;
+      inset:0;
+      z-index:80;
+      display:none;
+    }
+    .feed-detail-modal.open{display:block}
+    .feed-detail-backdrop{
+      position:absolute;
+      inset:0;
+      background:rgba(20,17,14,.48);
+      backdrop-filter:blur(2px);
+    }
+    .feed-detail-sheet{
+      position:absolute;
+      left:50%;
+      bottom:0;
+      transform:translateX(-50%);
+      width:min(520px,100%);
+      border-radius:28px 28px 0 0;
+      background:#fff;
+      padding:18px 16px 20px;
+      box-shadow:0 -10px 28px rgba(0,0,0,.18);
+    }
+    .feed-detail-close{
+      border:none;
+      background:#f4efe6;
+      width:34px;
+      height:34px;
+      border-radius:50%;
+      font-size:22px;
+      line-height:1;
+      margin-left:auto;
+      display:block;
+      cursor:pointer;
+    }
+    .feed-detail-emoji{
+      width:84px;
+      height:84px;
+      border-radius:24px;
+      background:#f8f4eb;
+      border:1px solid #eee4d8;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      font-size:44px;
+      margin:4px auto 10px;
+    }
+    .feed-detail-content h3{
+      font-size:21px;
+      margin:0;
+      text-align:center;
+      font-weight:900;
+      line-height:1.2;
+    }
+    .feed-detail-meta{
+      margin:8px 0 0;
+      text-align:center;
+      font-size:13px;
+      color:#736b62;
+    }
+    .feed-detail-price{
+      margin-top:14px;
+      font-size:24px;
+      font-weight:900;
+      color:#2953da;
+      text-align:center;
+    }
+    .feed-detail-wanted{
+      margin-top:10px;
+      padding:12px;
+      border-radius:14px;
+      background:#f8f5ef;
+      border:1px solid #ece2d6;
+      font-size:14px;
+      line-height:1.45;
+    }
+    .feed-detail-actions{margin-top:14px}
     .auth-card,.panel,.list-card{background:#fff;border:1px solid var(--line);border-radius:28px;padding:16px;box-shadow:var(--shadow)}
     label{display:block;font-size:13px;font-weight:800;margin:12px 0 6px;color:#444}
     input,textarea,select{width:100%;border:1px solid var(--line);border-radius:18px;padding:14px 16px;font-size:16px;background:#fff;outline:none}
@@ -114,14 +409,17 @@
         <button class="icon-btn" onclick="showPage('page-profile')">👤</button>
       </div>
     </div>
-    <div class="search-row">
-      <div class="search"><span style="font-size:24px;margin-right:10px">🔎</span><input id="feedSearch" placeholder="ค้นหาในฟีด" oninput="loadFeed()"></div>
-      <button class="icon-btn" onclick="loadFeed()">⟳</button>
-    </div>
-    <div class="chips">
-      <button class="chip active" data-feed-filter="all" onclick="setFeedFilter('all', this)">ทั้งหมด</button>
-      <button class="chip" data-feed-filter="swap" onclick="setFeedFilter('swap', this)">Xwap ได้</button>
-      <button class="chip" data-feed-filter="both" onclick="setFeedFilter('both', this)">ทั้งขายทั้งแลก</button>
+    <div class="feed-top-sticky">
+      <div class="search-row">
+        <div class="search"><span style="font-size:24px;margin-right:10px">🔎</span><input id="feedSearch" placeholder="ค้นหาในฟีด" oninput="loadFeed()"></div>
+        <button class="icon-btn" onclick="loadFeed()">⟳</button>
+      </div>
+      <div class="chips">
+        <button class="chip active" data-feed-filter="all" onclick="setFeedFilter('all', this)">ทั้งหมด</button>
+        <button class="chip" data-feed-filter="swap" onclick="setFeedFilter('swap', this)">Xwap ได้</button>
+        <button class="chip" data-feed-filter="both" onclick="setFeedFilter('both', this)">ทั้งขายทั้งแลก</button>
+      </div>
+      <div id="feedCategoryRow" class="feed-category-row"></div>
     </div>
     <div id="feedNotice"></div>
     <div id="feedList" class="feed-list"></div>

--- a/artifacts/web-app/src/main.js
+++ b/artifacts/web-app/src/main.js
@@ -6,7 +6,7 @@ import {
   signOut,
   signInWithReplit,
 } from "./ui/auth.js";
-import { loadFeed, setFeedFilter } from "./ui/feed.js";
+import { loadFeed, setFeedFilter, setFeedCategory } from "./ui/feed.js";
 import {
   renderCategories,
   setCategory,
@@ -28,6 +28,7 @@ Object.assign(window, {
   signInWithReplit,
   loadFeed,
   setFeedFilter,
+  setFeedCategory,
   setCategory,
   setShopFilter,
   loadShop,

--- a/artifacts/web-app/src/state.js
+++ b/artifacts/web-app/src/state.js
@@ -2,6 +2,7 @@ export const state = {
   currentUser: null,
   shopFilter: "all",
   feedFilter: "all",
+  feedCategory: "all",
   inboxFilter: "action",
   currentCategory: "all",
 };

--- a/artifacts/web-app/src/ui/cards.js
+++ b/artifacts/web-app/src/ui/cards.js
@@ -3,6 +3,124 @@ import { state } from "../state.js";
 import { offers } from "../api.js";
 import { authGuard } from "./nav.js";
 
+const SAVED_ITEMS_KEY = "qxwap.saved-items";
+const FEED_DETAIL_MODAL_ID = "feedDetailModal";
+
+function readSavedItems() {
+  try {
+    const raw = window.localStorage.getItem(SAVED_ITEMS_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return new Set(Array.isArray(parsed) ? parsed : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function writeSavedItems(savedSet) {
+  window.localStorage.setItem(SAVED_ITEMS_KEY, JSON.stringify([...savedSet]));
+}
+
+function isSaved(itemId) {
+  return readSavedItems().has(itemId);
+}
+
+function toggleSaved(itemId) {
+  const saved = readSavedItems();
+  if (saved.has(itemId)) {
+    saved.delete(itemId);
+    writeSavedItems(saved);
+    return false;
+  }
+  saved.add(itemId);
+  writeSavedItems(saved);
+  return true;
+}
+
+function formatPrice(item) {
+  const cash = Number(item.priceCash || 0);
+  const credit = Number(item.priceCredit || 0);
+  if (item.dealType === "swap" && !cash && !credit) return "เปิดรับ Xwap";
+  if (cash && credit) {
+    return `฿${cash.toLocaleString()} + ${credit.toLocaleString()} เครดิต`;
+  }
+  if (cash) return `฿${cash.toLocaleString()}`;
+  if (credit) return `${credit.toLocaleString()} เครดิต`;
+  return "เปิดรับข้อเสนอ";
+}
+
+function dealTypeLabel(dealType) {
+  if (dealType === "both") return "ขาย/แลก";
+  if (dealType === "buy") return "ซื้อได้";
+  return "แลกได้";
+}
+
+function parseImageList(item) {
+  const candidates = [
+    item?.imageUrls,
+    item?.images,
+    item?.media,
+    item?.photos,
+    item?.image_url,
+    item?.imageUrl,
+  ];
+  for (const value of candidates) {
+    if (Array.isArray(value)) return value.filter(Boolean);
+    if (typeof value === "string" && value.trim()) {
+      if (value.includes(",")) {
+        return value
+          .split(",")
+          .map((x) => x.trim())
+          .filter(Boolean);
+      }
+      return [value];
+    }
+  }
+  return [];
+}
+
+function pickImage(item, side = "have") {
+  const images = parseImageList(item);
+  if (images.length === 0) return null;
+  if (side === "want" && images[1]) return images[1];
+  return images[0];
+}
+
+function requestPreviewRow(item) {
+  const requests = Array.isArray(item.requestPreview) ? item.requestPreview : [];
+  if (!requests.length) {
+    return `
+      <div class="feed-request-preview">
+        <div class="feed-request-avatars">
+          <span class="feed-request-avatar fallback">•</span>
+        </div>
+        <div class="feed-request-text">ยังไม่มีคำขอแลก · พร้อมรับข้อเสนอแรก</div>
+      </div>
+    `;
+  }
+  const avatars = requests
+    .slice(0, 3)
+    .map((entry, idx) => {
+      const initial = escapeHtml(
+        String(entry?.name || `U${idx + 1}`)
+          .trim()
+          .slice(0, 1)
+          .toUpperCase(),
+      );
+      if (entry?.avatar) {
+        return `<span class="feed-request-avatar"><img src="${escapeHtml(entry.avatar)}" alt="${initial}" loading="lazy" /></span>`;
+      }
+      return `<span class="feed-request-avatar">${initial}</span>`;
+    })
+    .join("");
+  const total = Number(item.requestCount || requests.length || 0);
+  return `
+    <div class="feed-request-preview">
+      <div class="feed-request-avatars">${avatars}</div>
+      <div class="feed-request-text">${total.toLocaleString()} คำขอสนใจรายการนี้</div>
+    </div>
+  `;
+}
+
 export function productCardHtml(item) {
   const buyBtn =
     item.dealType === "swap"
@@ -27,40 +145,179 @@ export function productCardHtml(item) {
 }
 
 export function feedCardHtml(item) {
+  const saved = isSaved(item.id);
+  const haveImg = pickImage(item, "have");
+  const wantImg = pickImage(item, "want");
+  const haveEmoji = escapeHtml(itemEmoji(item));
+  const wantedText = escapeHtml(item.wantedText || "ยังไม่ได้ระบุสิ่งที่อยากได้");
+  const cardTitle = escapeHtml(item.title || "รายการสำหรับ Xwap");
+  const location = escapeHtml(item.locationLabel || "Bangkok");
+  const category = escapeHtml(item.category || "อื่นๆ");
+  const deal = dealTypeLabel(item.dealType);
+  const price = escapeHtml(formatPrice(item));
+  const requestSummary = escapeHtml(item.requestSummary || wantedText);
+
   return `
-    <div class="feed-card" data-item-id="${escapeHtml(item.id)}" data-item-title="${escapeHtml(item.title || "")}" data-owner-id="${escapeHtml(item.ownerId)}">
-      <div class="swap-panels">
-        <div class="swap-panel">
+    <article
+      class="feed-card ${saved ? "saved" : ""}"
+      data-feed-card="1"
+      data-item-id="${escapeHtml(item.id)}"
+      data-item-title="${escapeHtml(item.title || "")}"
+      data-owner-id="${escapeHtml(item.ownerId)}"
+      data-item-location="${location}"
+      data-item-category="${category}"
+      data-item-deal="${escapeHtml(deal)}"
+      data-item-price="${price}"
+      data-item-wanted="${wantedText}"
+      data-item-emoji="${haveEmoji}"
+    >
+      <button
+        class="feed-save-btn ${saved ? "saved" : ""}"
+        data-save="1"
+        aria-label="${saved ? "ยกเลิกบันทึก" : "บันทึกรายการ"}"
+        aria-pressed="${saved ? "true" : "false"}"
+      >
+        <span class="feed-save-icon">${saved ? "★" : "☆"}</span>
+      </button>
+
+      <div class="swap-hero">
+        <div class="swap-half own">
           <div class="swap-label">มีอยู่</div>
-          <div class="swap-image">${escapeHtml(itemEmoji(item))}</div>
+          <div class="swap-media">
+            ${
+              haveImg
+                ? `<img src="${escapeHtml(haveImg)}" alt="${cardTitle}" loading="lazy" />`
+                : `<div class="swap-media-fallback">${haveEmoji}</div>`
+            }
+          </div>
         </div>
-        <div class="swap-panel">
+        <div class="swap-half want">
           <div class="swap-label right">อยากได้</div>
-          <div class="want-box"><div style="font-size:15px;font-weight:800;line-height:1.4">${escapeHtml(item.wantedText || "ยังไม่ได้ระบุ")}</div></div>
+          <div class="swap-media">
+            ${
+              wantImg
+                ? `<img src="${escapeHtml(wantImg)}" alt="${wantedText}" loading="lazy" />`
+                : `<div class="swap-media-wanted">${wantedText}</div>`
+            }
+          </div>
+        </div>
+        <button class="feed-xwap-cta" data-xwap="1" aria-label="ส่งคำขอ Xwap">
+          Xwap
+        </button>
+      </div>
+
+      <div class="feed-card-body">
+        <div class="swap-card-title">${cardTitle}</div>
+        <div class="swap-card-sub">${location} · ${category} · ${escapeHtml(deal)}</div>
+        <div class="feed-meta-row">
+          <div class="feed-price">${price}</div>
+          <div class="feed-request-summary">${requestSummary}</div>
+        </div>
+        ${requestPreviewRow(item)}
+        <div class="feed-actions">
+          <button class="btn primary" data-xwap="1">ส่งคำขอ Xwap</button>
+          <button class="btn ghost" data-open-detail="1">ดูรายละเอียด</button>
         </div>
       </div>
-      <div class="swap-card-title">${escapeHtml(item.title || "-")}</div>
-      <div class="swap-card-sub">${escapeHtml(item.locationLabel || "Bangkok")} · ${escapeHtml(item.category || "")}</div>
-      <div class="btn-row" style="margin-top:12px"><button class="btn primary" data-xwap="1">Xwap</button></div>
-    </div>`;
+    </article>`;
 }
 
 export function bindCardActions(container) {
-  container.querySelectorAll("[data-xwap]").forEach((btn) => {
-    btn.addEventListener("click", () => {
-      const card = btn.closest("[data-item-id]");
+  if (container.dataset.cardActionsBound === "1") return;
+  container.dataset.cardActionsBound = "1";
+
+  let touchStartX = 0;
+  let touchStartY = 0;
+  let swipeCard = null;
+
+  container.addEventListener(
+    "touchstart",
+    (event) => {
+      const card = event.target.closest("[data-feed-card]");
       if (!card) return;
+      if (event.target.closest("[data-xwap],[data-save],[data-open-detail]")) return;
+      const touch = event.changedTouches[0];
+      touchStartX = touch.clientX;
+      touchStartY = touch.clientY;
+      swipeCard = card;
+    },
+    { passive: true },
+  );
+
+  container.addEventListener(
+    "touchend",
+    (event) => {
+      if (!swipeCard) return;
+      const touch = event.changedTouches[0];
+      const dx = touch.clientX - touchStartX;
+      const dy = touch.clientY - touchStartY;
+      if (Math.abs(dx) > 68 && Math.abs(dy) < 44) {
+        const cls = dx > 0 ? "swiped-right" : "swiped-left";
+        swipeCard.classList.add(cls);
+        window.setTimeout(() => swipeCard?.classList.remove(cls), 320);
+      }
+      swipeCard = null;
+    },
+    { passive: true },
+  );
+
+  container.addEventListener("click", (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+
+    const buyBtn = target.closest("[data-buy-now]");
+    if (buyBtn) {
+      alert("เวอร์ชันนี้ยังไม่ได้ต่อ Buy flow");
+      return;
+    }
+
+    const saveBtn = target.closest("[data-save]");
+    if (saveBtn) {
+      const card = saveBtn.closest("[data-item-id]");
+      if (!card) return;
+      const itemId = card.getAttribute("data-item-id");
+      if (!itemId) return;
+      const saved = toggleSaved(itemId);
+      saveBtn.classList.toggle("saved", saved);
+      saveBtn.setAttribute("aria-pressed", saved ? "true" : "false");
+      saveBtn.setAttribute("aria-label", saved ? "ยกเลิกบันทึก" : "บันทึกรายการ");
+      const icon = saveBtn.querySelector(".feed-save-icon");
+      if (icon) icon.textContent = saved ? "★" : "☆";
+      const feedCard = saveBtn.closest(".feed-card");
+      if (feedCard) {
+        feedCard.classList.toggle("saved", saved);
+        feedCard.classList.add("save-bump");
+        window.setTimeout(() => feedCard.classList.remove("save-bump"), 240);
+      }
+      return;
+    }
+
+    const xwapBtn = target.closest("[data-xwap]");
+    if (xwapBtn) {
+      const card = xwapBtn.closest("[data-item-id]");
+      if (!card) return;
+      card.classList.add("xwap-active");
+      window.setTimeout(() => card.classList.remove("xwap-active"), 900);
       openOfferPrompt(
         card.getAttribute("data-item-id"),
         card.getAttribute("data-item-title") || "สินค้า",
         card.getAttribute("data-owner-id"),
       );
-    });
-  });
-  container.querySelectorAll("[data-buy-now]").forEach((btn) => {
-    btn.addEventListener("click", () =>
-      alert("เวอร์ชันนี้ยังไม่ได้ต่อ Buy flow"),
-    );
+      return;
+    }
+
+    const detailBtn = target.closest("[data-open-detail]");
+    if (detailBtn) {
+      const card = detailBtn.closest("[data-feed-card]");
+      if (!card) return;
+      openFeedDetail(card);
+      return;
+    }
+
+    const card = target.closest("[data-feed-card]");
+    if (card) {
+      openFeedDetail(card);
+    }
   });
 }
 
@@ -87,4 +344,68 @@ export async function openOfferPrompt(itemId, itemTitle, ownerId) {
   } catch (e) {
     alert("ส่งข้อเสนอไม่สำเร็จ: " + String(e?.message || e));
   }
+}
+
+function ensureFeedDetailModal() {
+  let modal = document.getElementById(FEED_DETAIL_MODAL_ID);
+  if (modal) return modal;
+  modal = document.createElement("div");
+  modal.id = FEED_DETAIL_MODAL_ID;
+  modal.className = "feed-detail-modal";
+  modal.innerHTML = `
+    <div class="feed-detail-backdrop" data-close-feed-detail="1"></div>
+    <div class="feed-detail-sheet" role="dialog" aria-modal="true" aria-label="รายละเอียดสินค้า">
+      <button class="feed-detail-close" data-close-feed-detail="1" aria-label="ปิด">×</button>
+      <div class="feed-detail-content"></div>
+    </div>
+  `;
+  document.body.appendChild(modal);
+  modal.addEventListener("click", (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    if (target.closest("[data-close-feed-detail]")) {
+      closeFeedDetail();
+    }
+  });
+  return modal;
+}
+
+function openFeedDetail(card) {
+  const modal = ensureFeedDetailModal();
+  const content = modal.querySelector(".feed-detail-content");
+  if (!content) return;
+  const itemTitle = card.getAttribute("data-item-title") || "รายการสำหรับ Xwap";
+  const wanted = card.getAttribute("data-item-wanted") || "ยังไม่ได้ระบุ";
+  const location = card.getAttribute("data-item-location") || "Bangkok";
+  const category = card.getAttribute("data-item-category") || "-";
+  const deal = card.getAttribute("data-item-deal") || "แลกได้";
+  const price = card.getAttribute("data-item-price") || "เปิดรับข้อเสนอ";
+  const emoji = card.getAttribute("data-item-emoji") || "📦";
+  content.innerHTML = `
+    <div class="feed-detail-emoji">${emoji}</div>
+    <h3>${escapeHtml(itemTitle)}</h3>
+    <p class="feed-detail-meta">${escapeHtml(location)} · ${escapeHtml(category)} · ${escapeHtml(deal)}</p>
+    <div class="feed-detail-price">${escapeHtml(price)}</div>
+    <div class="feed-detail-wanted"><strong>อยากได้:</strong> ${escapeHtml(wanted)}</div>
+    <div class="feed-detail-actions">
+      <button class="btn primary" data-feed-detail-xwap="1">ส่งคำขอ Xwap</button>
+    </div>
+  `;
+  content.querySelector("[data-feed-detail-xwap]")?.addEventListener("click", () => {
+    closeFeedDetail();
+    openOfferPrompt(
+      card.getAttribute("data-item-id"),
+      card.getAttribute("data-item-title") || "สินค้า",
+      card.getAttribute("data-owner-id"),
+    );
+  });
+  modal.classList.add("open");
+  document.body.classList.add("modal-open");
+}
+
+function closeFeedDetail() {
+  const modal = document.getElementById(FEED_DETAIL_MODAL_ID);
+  if (!modal) return;
+  modal.classList.remove("open");
+  document.body.classList.remove("modal-open");
 }

--- a/artifacts/web-app/src/ui/feed.js
+++ b/artifacts/web-app/src/ui/feed.js
@@ -1,10 +1,63 @@
 import { qs, notify } from "../util.js";
-import { state } from "../state.js";
+import { state, categories } from "../state.js";
 import { items } from "../api.js";
 import { authGuard } from "./nav.js";
 import { feedCardHtml, bindCardActions } from "./cards.js";
 
 export { feedCardHtml };
+
+const FALLBACK_FEED_ITEMS = [
+  {
+    id: "fallback-phone-1",
+    ownerId: "seed-owner-1",
+    title: "iPhone 14 Pro Max 256GB",
+    category: "phone",
+    locationLabel: "Bangkok",
+    dealType: "both",
+    priceCash: 28900,
+    wantedText: "MacBook Air M1 หรือ iPad Pro พร้อม Apple Pencil",
+    requestSummary: "เปิดรับข้อเสนอของใกล้เคียง",
+    conditionLabel: "สภาพดี",
+    imageEmoji: "📱",
+    requestCount: 12,
+    requestPreview: [
+      { name: "Mint", avatar: "" },
+      { name: "Tee", avatar: "" },
+      { name: "Ploy", avatar: "" },
+    ],
+  },
+  {
+    id: "fallback-laptop-2",
+    ownerId: "seed-owner-2",
+    title: "MacBook Pro 14” M2 พร้อมกล่อง",
+    category: "electronics",
+    locationLabel: "ลาดพร้าว",
+    dealType: "swap",
+    priceCash: 0,
+    priceCredit: 0,
+    wantedText: "Sony A6400 + เลนส์ หรือเครดิตมูลค่าใกล้เคียง",
+    requestSummary: "อยากได้กล้อง mirrorless",
+    conditionLabel: "สภาพดีมาก",
+    imageEmoji: "💻",
+    requestCount: 8,
+    requestPreview: [{ name: "Aom" }, { name: "Beam" }],
+  },
+  {
+    id: "fallback-fashion-3",
+    ownerId: "seed-owner-3",
+    title: "Nike Dunk Low Panda ไซซ์ 42",
+    category: "fashion",
+    locationLabel: "ใกล้ฉัน",
+    dealType: "both",
+    priceCash: 3900,
+    wantedText: "Stussy Jacket สีดำ ไซซ์ M",
+    requestSummary: "พร้อมแลกเสื้อผ้าสตรีทแวร์",
+    conditionLabel: "95%",
+    imageEmoji: "👟",
+    requestCount: 3,
+    requestPreview: [{ name: "Ken" }],
+  },
+];
 
 export function setFeedFilter(filter, btn) {
   state.feedFilter = filter;
@@ -12,25 +65,158 @@ export function setFeedFilter(filter, btn) {
     .querySelectorAll("[data-feed-filter]")
     .forEach((x) => x.classList.remove("active"));
   if (btn) btn.classList.add("active");
+  syncFeedFilterButtons();
   loadFeed();
+}
+
+export function setFeedCategory(category, btn) {
+  state.feedCategory = category;
+  document
+    .querySelectorAll("[data-feed-category]")
+    .forEach((x) => x.classList.remove("active"));
+  if (btn) btn.classList.add("active");
+  syncFeedCategoryButtons();
+  loadFeed();
+}
+
+function feedSkeletonCardHtml() {
+  return `
+    <article class="feed-card skeleton-card" aria-hidden="true">
+      <div class="swap-hero">
+        <div class="swap-half"><div class="swap-media skeleton-block"></div></div>
+        <div class="swap-half"><div class="swap-media skeleton-block"></div></div>
+      </div>
+      <div class="feed-card-body">
+        <div class="skeleton-line w-70"></div>
+        <div class="skeleton-line w-55"></div>
+        <div class="skeleton-line w-85"></div>
+      </div>
+    </article>
+  `;
+}
+
+function emptyFeedStateHtml() {
+  return `
+    <div class="empty feed-empty-state">
+      <div class="feed-empty-title">ยังไม่พบรายการที่ตรงกับเงื่อนไข</div>
+      <div class="feed-empty-sub">ลองเปลี่ยนคำค้นหา ตัวกรอง หรือหมวดหมู่</div>
+    </div>
+  `;
+}
+
+function fallbackFeedStateHtml(list) {
+  return `
+    <div class="empty feed-fallback-state">
+      <div class="feed-empty-title">ยังไม่มีข้อมูลจากฐานข้อมูลในตอนนี้</div>
+      <div class="feed-empty-sub">แสดงการ์ดตัวอย่างเพื่อให้ฟีดไม่ว่างเปล่า</div>
+    </div>
+    ${list.map(feedCardHtml).join("")}
+  `;
+}
+
+function normalizeFeedItem(item) {
+  return {
+    id: item?.id || `item-${Math.random().toString(16).slice(2)}`,
+    ownerId: item?.ownerId || "",
+    title: item?.title || "รายการสำหรับ Xwap",
+    category: item?.category || "อื่นๆ",
+    locationLabel: item?.locationLabel || "Bangkok",
+    dealType: item?.dealType || "swap",
+    priceCash: Number(item?.priceCash || 0),
+    priceCredit: Number(item?.priceCredit || 0),
+    wantedText: item?.wantedText || "",
+    requestSummary: item?.requestSummary || "",
+    requestCount: Number(item?.requestCount || 0),
+    requestPreview: Array.isArray(item?.requestPreview) ? item.requestPreview : [],
+    imageEmoji: item?.imageEmoji || "📦",
+    conditionLabel: item?.conditionLabel || "สภาพดี",
+    imageUrls: Array.isArray(item?.imageUrls) ? item.imageUrls : undefined,
+    imageUrl: typeof item?.imageUrl === "string" ? item.imageUrl : undefined,
+    images: Array.isArray(item?.images) ? item.images : undefined,
+  };
+}
+
+function renderFeedSkeleton(feed) {
+  feed.innerHTML = Array.from({ length: 3 }, feedSkeletonCardHtml).join("");
+}
+
+function syncFeedFilterButtons() {
+  document.querySelectorAll("[data-feed-filter]").forEach((button) => {
+    const isActive = button.getAttribute("data-feed-filter") === state.feedFilter;
+    button.classList.toggle("active", isActive);
+  });
+}
+
+function renderFeedCategoryRow() {
+  const row = qs("feedCategoryRow");
+  if (!row) return;
+  row.innerHTML = categories
+    .map((cat) => {
+      const active = state.feedCategory === cat.key;
+      return `
+      <button
+        type="button"
+        class="feed-category-chip ${active ? "active" : ""}"
+        data-feed-category="${cat.key}"
+        aria-pressed="${active ? "true" : "false"}"
+      >
+        <span class="feed-category-icon">${cat.icon}</span>
+        <span>${cat.name}</span>
+      </button>
+    `;
+    })
+    .join("");
+  row.querySelectorAll("[data-feed-category]").forEach((button) => {
+    button.addEventListener("click", () =>
+      setFeedCategory(button.getAttribute("data-feed-category"), button),
+    );
+  });
+}
+
+function syncFeedCategoryButtons() {
+  document.querySelectorAll("[data-feed-category]").forEach((button) => {
+    const isActive = button.getAttribute("data-feed-category") === state.feedCategory;
+    button.classList.toggle("active", isActive);
+    button.setAttribute("aria-pressed", isActive ? "true" : "false");
+  });
 }
 
 export async function loadFeed() {
   if (!authGuard()) return;
   notify("feedNotice", "", "");
   const search = qs("feedSearch").value.trim();
+  const feed = qs("feedList");
+  renderFeedCategoryRow();
+  syncFeedFilterButtons();
+  syncFeedCategoryButtons();
+  renderFeedSkeleton(feed);
+
   const params = { search };
   if (state.feedFilter === "swap") params.deal_type = "swap";
   if (state.feedFilter === "both") params.deal_type = "both";
+  if (state.feedFilter === "all") params.deal_type = "feed";
+  if (state.feedCategory !== "all") params.category = state.feedCategory;
+
+  const hasFilterApplied =
+    Boolean(search) || state.feedFilter !== "all" || state.feedCategory !== "all";
+
   try {
     let { items: list } = await items.list(params);
-    list = list.filter((i) => i.dealType !== "buy");
-    const feed = qs("feedList");
-    feed.innerHTML = list.length
-      ? list.map(feedCardHtml).join("")
-      : `<div class="empty">ยังไม่มีสินค้าในฟีด</div>`;
+    list = (Array.isArray(list) ? list : [])
+      .filter((i) => i?.dealType !== "buy")
+      .map(normalizeFeedItem);
+
+    if (list.length) {
+      feed.innerHTML = list.map(feedCardHtml).join("");
+    } else if (hasFilterApplied) {
+      feed.innerHTML = emptyFeedStateHtml();
+    } else {
+      feed.innerHTML = fallbackFeedStateHtml(FALLBACK_FEED_ITEMS);
+    }
     bindCardActions(feed);
   } catch (e) {
     notify("feedNotice", "error", String(e?.message || e));
+    feed.innerHTML = fallbackFeedStateHtml(FALLBACK_FEED_ITEMS);
+    bindCardActions(feed);
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
- Rebuilt the Feed screen around the original split swap-card layout from the reference (owned item left, wanted item right, floating center Xwap CTA, save icon, meta hierarchy, request preview row, and CTA area).
- Added sticky feed top controls (search, filter chips, horizontal category chips) with mobile-first spacing and behavior.
- Added robust feed states: loading skeleton cards, empty state for filtered/no-match results, and fallback feed cards when DB data is empty or fetch fails.
- Added feed interactions: card tap opens detail sheet, Xwap CTA triggers offer flow with visual feedback, save icon toggles bookmark state with visual feedback, and safe swipe gesture feedback.
- Kept feed-card rendering centralized in `src/ui/cards.js` and wired feed filters/categories in `src/ui/feed.js` without changing unrelated pages.

## Walkthrough artifacts
[feed_reference_ui_behavior_walkthrough.mp4](https://cursor.com/agents/bc-b21c5ba7-bde9-4fb6-998f-0a426d021c27/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeed_reference_ui_behavior_walkthrough.mp4)

[Feed split swap cards](https://cursor.com/agents/bc-b21c5ba7-bde9-4fb6-998f-0a426d021c27/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeed_split_swap_cards.webp)
[Feed sticky top controls on scroll](https://cursor.com/agents/bc-b21c5ba7-bde9-4fb6-998f-0a426d021c27/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeed_sticky_header_scroll.webp)
[Feed empty state when filtered](https://cursor.com/agents/bc-b21c5ba7-bde9-4fb6-998f-0a426d021c27/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeed_empty_state_filter.webp)

## Validation done
- `pnpm --filter @workspace/web-app run typecheck`
- `PORT=4173 BASE_PATH=/ pnpm --filter @workspace/web-app run build`
- Manual browser walkthrough for feed layout and interactions (save, Xwap prompt/confirm, detail sheet, sticky top area, empty-state filter behavior).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b21c5ba7-bde9-4fb6-998f-0a426d021c27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b21c5ba7-bde9-4fb6-998f-0a426d021c27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

