### PR TITLE
Complete database-backed item routes

### DIFF
--- a/artifacts/api-server/src/routes/items.ts
+++ b/artifacts/api-server/src/routes/items.ts
@@ -1,12 +1,40 @@
 import { Router, type IRouter, type Request, type Response } from "express";
 import { db, itemsTable, insertItemSchema } from "@workspace/db";
 import { and, desc, eq, ilike, inArray } from "drizzle-orm";
+import { z } from "zod/v4";
 import { requireAuth } from "../middlewares/authMiddleware";
 
 const router: IRouter = Router();
+const publicItemStatus = "active" as const;
+
+const createItemSchema = insertItemSchema.omit({
+  ownerId: true,
+  status: true,
+});
+
+const updateItemSchema = createItemSchema
+  .partial()
+  .extend({
+    status: z.enum(["active", "paused", "closed"]).optional(),
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "ต้องมีข้อมูลอย่างน้อย 1 ฟิลด์",
+  });
+
+function canAccessOwnItems(req: Request, ownerId: string | null): boolean {
+  return Boolean(ownerId && req.isAuthenticated() && req.user.id === ownerId);
+}
+
+function canViewItem(req: Request, item: typeof itemsTable.$inferSelect): boolean {
+  return item.status === publicItemStatus || canAccessOwnItems(req, item.ownerId);
+}
 
 router.get("/items", async (req: Request, res: Response) => {
-  const conditions = [eq(itemsTable.status, "active" as const)];
+  const conditions = [];
+  const ownerId = typeof req.query.owner_id === "string" ? req.query.owner_id : null;
+  if (!canAccessOwnItems(req, ownerId)) {
+    conditions.push(eq(itemsTable.status, publicItemStatus));
+  }
 
   const category = typeof req.query.category === "string" ? req.query.category : null;
   if (category && category !== "all") {
@@ -30,7 +58,6 @@ router.get("/items", async (req: Request, res: Response) => {
     conditions.push(ilike(itemsTable.title, `%${search}%`));
   }
 
-  const ownerId = typeof req.query.owner_id === "string" ? req.query.owner_id : null;
   if (ownerId) {
     conditions.push(eq(itemsTable.ownerId, ownerId));
   }
@@ -44,11 +71,23 @@ router.get("/items", async (req: Request, res: Response) => {
   res.json({ items: rows });
 });
 
+router.get("/items/:id", async (req: Request, res: Response) => {
+  const [item] = await db
+    .select()
+    .from(itemsTable)
+    .where(eq(itemsTable.id, String(req.params.id)));
+
+  if (!item || !canViewItem(req, item)) {
+    res.status(404).json({ error: "ไม่พบสินค้า" });
+    return;
+  }
+
+  res.json({ item });
+});
+
 router.post("/items", requireAuth, async (req: Request, res: Response) => {
   if (!req.isAuthenticated()) return;
-  const parsed = insertItemSchema
-    .omit({ ownerId: true })
-    .safeParse(req.body);
+  const parsed = createItemSchema.safeParse(req.body);
   if (!parsed.success) {
     res.status(400).json({ error: "ข้อมูลสินค้าไม่ครบ", details: parsed.error.issues });
     return;
@@ -58,6 +97,64 @@ router.post("/items", requireAuth, async (req: Request, res: Response) => {
     .values({ ...parsed.data, ownerId: req.user.id })
     .returning();
   res.json({ item: created });
+});
+
+router.patch("/items/:id", requireAuth, async (req: Request, res: Response) => {
+  if (!req.isAuthenticated()) return;
+
+  const parsed = updateItemSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: "ข้อมูลสินค้าที่ต้องการแก้ไขไม่ถูกต้อง" });
+    return;
+  }
+
+  const [item] = await db
+    .select()
+    .from(itemsTable)
+    .where(eq(itemsTable.id, String(req.params.id)));
+
+  if (!item) {
+    res.status(404).json({ error: "ไม่พบสินค้า" });
+    return;
+  }
+
+  if (item.ownerId !== req.user.id) {
+    res.status(403).json({ error: "แก้ไขได้เฉพาะสินค้าของตัวเอง" });
+    return;
+  }
+
+  const [updated] = await db
+    .update(itemsTable)
+    .set(parsed.data)
+    .where(eq(itemsTable.id, item.id))
+    .returning();
+
+  res.json({ item: updated });
+});
+
+router.delete("/items/:id", requireAuth, async (req: Request, res: Response) => {
+  if (!req.isAuthenticated()) return;
+
+  const [item] = await db
+    .select()
+    .from(itemsTable)
+    .where(eq(itemsTable.id, String(req.params.id)));
+
+  if (!item) {
+    res.status(404).json({ error: "ไม่พบสินค้า" });
+    return;
+  }
+
+  if (item.ownerId !== req.user.id) {
+    res.status(403).json({ error: "ลบได้เฉพาะสินค้าของตัวเอง" });
+    return;
+  }
+
+  await db.delete(itemsTable).where(
+    and(eq(itemsTable.id, item.id), eq(itemsTable.ownerId, req.user.id)),
+  );
+
+  res.json({ ok: true });
 });
 
 export default router;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- finish the existing Drizzle-backed item flow in `api-server`
- add item detail lookup while keeping non-public items visible only to their owner
- add owner-only update and owner-only delete endpoints
- preserve the current frontend-facing list/create response shape

## Testing
- `pnpm --filter @workspace/api-server run typecheck`
- `pnpm --filter @workspace/api-server run build`
- runtime HTTP verification is blocked in this cloud shell because `DATABASE_URL` and `SESSION_SECRET` are not present, and no local Postgres runtime is installed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1ebfe3b-e183-404d-bf95-59512e580d4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1ebfe3b-e183-404d-bf95-59512e580d4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

