### PR TITLE
Continue deals DB integration with stage progression APIs

### DIFF
--- a/artifacts/api-server/src/routes/deals.ts
+++ b/artifacts/api-server/src/routes/deals.ts
@@ -1,0 +1,170 @@
+import { Router, type IRouter, type Request, type Response } from "express";
+import { db, dealsTable, itemsTable, offersTable } from "@workspace/db";
+import { and, desc, eq, or } from "drizzle-orm";
+import { z } from "zod/v4";
+import { requireAuth } from "../middlewares/authMiddleware";
+
+const router: IRouter = Router();
+
+const dealStages = [
+  "accepted",
+  "logistics_pending",
+  "shipped_or_pickup_set",
+  "received",
+  "completed",
+  "canceled",
+] as const;
+
+type DealStage = (typeof dealStages)[number];
+
+const updateDealStageSchema = z.object({
+  stage: z.enum(dealStages),
+});
+
+const allowedTransitions: Record<DealStage, readonly DealStage[]> = {
+  accepted: ["logistics_pending", "canceled"],
+  logistics_pending: ["shipped_or_pickup_set", "canceled"],
+  shipped_or_pickup_set: ["received", "canceled"],
+  received: ["completed"],
+  completed: [],
+  canceled: [],
+};
+
+function isDealStage(stage: string): stage is DealStage {
+  return dealStages.includes(stage as DealStage);
+}
+
+router.get("/deals/mine", requireAuth, async (req: Request, res: Response) => {
+  if (!req.isAuthenticated()) return;
+  const uid = req.user.id;
+
+  const rows = await db
+    .select({
+      deal: dealsTable,
+      itemTitle: itemsTable.title,
+      offerStatus: offersTable.status,
+    })
+    .from(dealsTable)
+    .leftJoin(itemsTable, eq(dealsTable.targetItemId, itemsTable.id))
+    .leftJoin(offersTable, eq(dealsTable.offerId, offersTable.id))
+    .where(or(eq(dealsTable.senderId, uid), eq(dealsTable.receiverId, uid)))
+    .orderBy(desc(dealsTable.createdAt));
+
+  res.json({
+    deals: rows.map((row) => ({
+      ...row.deal,
+      item: { title: row.itemTitle },
+      offer: { status: row.offerStatus },
+    })),
+  });
+});
+
+router.get("/deals/:id", requireAuth, async (req: Request, res: Response) => {
+  if (!req.isAuthenticated()) return;
+  const uid = req.user.id;
+  const dealId = String(req.params.id);
+
+  const [row] = await db
+    .select({
+      deal: dealsTable,
+      itemTitle: itemsTable.title,
+      offerStatus: offersTable.status,
+      offerMessage: offersTable.message,
+      offeredCash: offersTable.offeredCash,
+      offeredCredit: offersTable.offeredCredit,
+    })
+    .from(dealsTable)
+    .leftJoin(itemsTable, eq(dealsTable.targetItemId, itemsTable.id))
+    .leftJoin(offersTable, eq(dealsTable.offerId, offersTable.id))
+    .where(eq(dealsTable.id, dealId));
+
+  if (!row) {
+    res.status(404).json({ error: "ไม่พบดีล" });
+    return;
+  }
+
+  if (row.deal.senderId !== uid && row.deal.receiverId !== uid) {
+    res.status(403).json({ error: "ไม่มีสิทธิ์เข้าถึงดีลนี้" });
+    return;
+  }
+
+  res.json({
+    deal: {
+      ...row.deal,
+      item: { title: row.itemTitle },
+      offer: {
+        status: row.offerStatus,
+        message: row.offerMessage,
+        offeredCash: row.offeredCash,
+        offeredCredit: row.offeredCredit,
+      },
+    },
+  });
+});
+
+router.patch(
+  "/deals/:id/stage",
+  requireAuth,
+  async (req: Request, res: Response) => {
+    if (!req.isAuthenticated()) return;
+    const uid = req.user.id;
+    const dealId = String(req.params.id);
+
+    const parsed = updateDealStageSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: "stage ไม่ถูกต้อง" });
+      return;
+    }
+
+    const [deal] = await db
+      .select()
+      .from(dealsTable)
+      .where(eq(dealsTable.id, dealId));
+
+    if (!deal) {
+      res.status(404).json({ error: "ไม่พบดีล" });
+      return;
+    }
+
+    if (deal.senderId !== uid && deal.receiverId !== uid) {
+      res.status(403).json({ error: "ไม่มีสิทธิ์อัปเดตดีลนี้" });
+      return;
+    }
+
+    if (!isDealStage(deal.stage)) {
+      res.status(409).json({ error: "สถานะดีลปัจจุบันไม่รองรับการเปลี่ยนขั้น" });
+      return;
+    }
+
+    const nextStage = parsed.data.stage;
+    if (!allowedTransitions[deal.stage].includes(nextStage)) {
+      res.status(409).json({ error: "เปลี่ยนขั้นดีลไม่ถูกต้อง" });
+      return;
+    }
+
+    const [updated] = await db
+      .update(dealsTable)
+      .set({
+        stage: nextStage,
+        logisticsConfirmed:
+          nextStage === "shipped_or_pickup_set" || nextStage === "received"
+            ? true
+            : deal.logisticsConfirmed,
+      })
+      .where(eq(dealsTable.id, deal.id))
+      .returning();
+
+    if (nextStage === "canceled") {
+      await db
+        .update(offersTable)
+        .set({ status: "canceled" })
+        .where(
+          and(eq(offersTable.id, deal.offerId), eq(offersTable.status, "accepted")),
+        );
+    }
+
+    res.json({ deal: updated });
+  },
+);
+
+export default router;

--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -5,6 +5,7 @@ import authRouter from "./auth";
 import itemsRouter from "./items";
 import offersRouter from "./offers";
 import profilesRouter from "./profiles";
+import dealsRouter from "./deals";
 
 const router: IRouter = Router();
 
@@ -14,5 +15,6 @@ router.use(authRouter);
 router.use(itemsRouter);
 router.use(offersRouter);
 router.use(profilesRouter);
+router.use(dealsRouter);
 
 export default router;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add new authenticated `deals` routes backed by database queries
- add `GET /deals/mine` and `GET /deals/:id` with strict participant-only visibility
- add `PATCH /deals/:id/stage` with explicit allowed transitions for deal lifecycle and valid cancel transitions
- wire new deals router into API route registration

## Testing
- `pnpm --filter @workspace/api-server run typecheck`
- `pnpm --filter @workspace/api-server run build`

## Notes
- no UI changes
- no schema changes
- runtime API smoke tests were not possible in this environment because `DATABASE_URL` and `SESSION_SECRET` are not set
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46407851-9228-44fd-b18a-6d1fc4e6b1b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46407851-9228-44fd-b18a-6d1fc4e6b1b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

