### PR TITLE
fix(web-app): gate Add Product screen behind real auth check

### DIFF
--- a/artifacts/web-app/index.html
+++ b/artifacts/web-app/index.html
@@ -3076,6 +3076,13 @@ h1,h2,h3{font-weight:900;}
         if(currentUser?.id){
           const meLabel = profileMap.get(currentUser.id);
           if(meLabel) viewerName = meLabel;
+          profileDirectory.self = {
+            ...profileDirectory.self,
+            name: meLabel || currentUser.email || profileDirectory.self.name,
+            handle: `@${(currentUser.email || '').split('@')[0].replace(/[^a-z0-9]+/gi,'').toLowerCase() || 'me'}`,
+            img: profileDirectory.self.img,
+            trust: 'บัญชียืนยันแล้ว',
+          };
         }
 
         const mappedFeed = apiItems.map((item) => {
@@ -4830,6 +4837,19 @@ function renderFeed(){
 
     function openAddProductScreen(skipHistory=false){
       console.log('[add] click');
+      if(!currentUser){
+        apiRequest('/auth/me').then(payload => {
+          if(payload?.user){
+            currentUser = payload.user;
+            openAddProductScreen(skipHistory);
+          } else {
+            showToast('กรุณาเข้าสู่ระบบก่อนเพิ่มสินค้า');
+          }
+        }).catch(() => {
+          showToast('กรุณาเข้าสู่ระบบก่อนเพิ่มสินค้า');
+        });
+        return;
+      }
       appState.screen = 'add';
       appState.searchOpen = false;
       appState.detailOpen = false;
@@ -4851,10 +4871,6 @@ function renderFeed(){
       const title = String(draft.title || '').trim();
       if(!title){
         showToast('กรอกชื่อสินค้าก่อนโพสต์');
-        return;
-      }
-      if(!currentUser){
-        showToast('กรุณาเข้าสู่ระบบก่อนโพสต์สินค้า');
         return;
       }
       const priceCash = Math.max(0, Number(draft.priceCash || 0));


### PR DESCRIPTION
## Summary

- ย้าย auth guard จาก `submitAddProduct()` ไปที่ `openAddProductScreen()` — user ที่ไม่ได้ login จะไม่เห็น form เลย
- Handle race condition: ถ้า `currentUser` ยัง null (page เพิ่ง load) → re-check `/auth/me` ก่อน ถ้า login แล้วจะเปิด form ให้อัตโนมัติ ไม่ block ผิด
- ลบ redundant `currentUser` toast ใน `submitAddProduct` ออก (ไม่จำเป็นอีกต่อไป)
- `hydrateFromApi` ตอนนี้ overwrite `profileDirectory.self` ด้วยข้อมูลจริงจาก API — profile ไม่แสดง mock "Sarun Chantanaree" ให้คนที่ login แล้ว

## Test plan

- [ ] ไม่ login → กด + (Add) → เห็น toast "กรุณาเข้าสู่ระบบก่อนเพิ่มสินค้า" ไม่เปิด form
- [ ] Login แล้ว → กด + → เปิด Add Product form ได้ปกติ
- [ ] Login แล้ว reload page → กด + ทันที (ก่อน hydrateFromApi เสร็จ) → ยังเปิด form ได้ (re-check auth อัตโนมัติ)
- [ ] Profile screen แสดงชื่อและ handle จากบัญชีจริง ไม่ใช่ Sarun Chantanaree

https://claude.ai/code/session_01KuxsH2oXscveFQSyhwdjwK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuxsH2oXscveFQSyhwdjwK)_