### PR TITLE
feat(web-app): add login/signup screen and logout flow

### DIFF
--- a/artifacts/web-app/index.html
+++ b/artifacts/web-app/index.html
@@ -1728,6 +1728,24 @@ h1,h2,h3{font-weight:900;}
 .settings-sheet.open{transform:translateX(-50%) translateY(0)}
 .settings-card{background:var(--card);box-shadow:var(--shadow);border-radius:24px;padding:16px}
 .inbox-nav-badge{position:absolute;top:5px;right:24px;background:var(--brand);color:#fff;box-shadow:0 8px 14px rgba(63,109,246,.22)}
+.screen-login{display:none;min-height:100vh;align-items:center;justify-content:center;background:var(--bg);padding:24px 20px}
+.screen-login.active{display:flex;flex-direction:column}
+.login-brand{font-size:38px;font-weight:900;letter-spacing:-.06em;text-align:center;margin-bottom:32px}
+.login-brand span{color:var(--brand)}
+.login-card{width:100%;max-width:380px;background:var(--card);border-radius:28px;box-shadow:var(--shadow);padding:24px 20px;margin:0 auto}
+.login-tabs{display:flex;gap:6px;background:var(--surface);border-radius:14px;padding:4px;margin-bottom:22px}
+.login-tab{flex:1;height:38px;border:none;border-radius:11px;background:none;font-size:14px;font-weight:800;color:var(--muted);cursor:pointer;transition:.15s ease}
+.login-tab.active{background:var(--card);color:var(--text);box-shadow:0 2px 8px rgba(19,16,13,.08)}
+.login-field{display:flex;flex-direction:column;gap:6px;margin-bottom:14px}
+.login-field label{font-size:13px;font-weight:800;color:#4a433c}
+.login-field input{height:50px;border-radius:14px;border:1.5px solid rgba(23,22,20,.1);background:#faf8f5;padding:0 14px;font-size:15px;color:var(--text);outline:none;transition:.15s ease}
+.login-field input:focus{border-color:var(--brand);background:#fff}
+.login-submit{width:100%;height:52px;border:none;border-radius:16px;background:linear-gradient(180deg,#5881ff,#3f6df6);color:#fff;font-size:16px;font-weight:900;letter-spacing:.02em;cursor:pointer;margin-top:6px;box-shadow:0 12px 22px rgba(63,109,246,.18)}
+.login-submit:disabled{opacity:.6;cursor:not-allowed}
+.login-error{margin-top:12px;padding:10px 14px;border-radius:12px;background:#fff0ee;color:#c0392b;font-size:13px;font-weight:700}
+.login-divider{display:flex;align-items:center;gap:10px;margin:16px 0;color:var(--muted);font-size:12px;font-weight:700}
+.login-divider::before,.login-divider::after{content:'';flex:1;height:1px;background:rgba(23,22,20,.08)}
+.logout-btn{width:100%;height:48px;border:1.5px solid rgba(220,50,50,.18);border-radius:14px;background:#fff8f7;color:#c0392b;font-size:14px;font-weight:800;cursor:pointer;margin-top:8px}
 </style>
 
 </head>
@@ -2374,6 +2392,26 @@ h1,h2,h3{font-weight:900;}
       </main>
     </section>
 
+    <section class="screen screen-login" id="screen-login">
+      <div class="login-brand">Q<span>X</span>wap</div>
+      <div class="login-card">
+        <div class="login-tabs">
+          <button class="login-tab active" id="loginTabSignin" onclick="setLoginTab('signin')">เข้าสู่ระบบ</button>
+          <button class="login-tab" id="loginTabSignup" onclick="setLoginTab('signup')">สมัครสมาชิก</button>
+        </div>
+        <div class="login-field">
+          <label>อีเมล</label>
+          <input type="email" id="loginEmail" placeholder="your@email.com" autocomplete="email" />
+        </div>
+        <div class="login-field">
+          <label>รหัสผ่าน</label>
+          <input type="password" id="loginPassword" placeholder="รหัสผ่าน 6 ตัวขึ้นไป" autocomplete="current-password" onkeydown="if(event.key==='Enter') submitLogin()" />
+        </div>
+        <button class="login-submit" id="loginSubmitBtn" onclick="submitLogin()">เข้าสู่ระบบ</button>
+        <div id="loginError" class="login-error" style="display:none"></div>
+      </div>
+    </section>
+
     <nav class="bottom-nav">
       <button class="nav-item active" data-target="feed" onclick="go('feed')">
         <div class="nav-icon"><svg><use href="#i-feed"/></svg></div>
@@ -2578,6 +2616,8 @@ h1,h2,h3{font-weight:900;}
           <div class="menu-item"><div class="menu-icon"><svg><use href="#i-chat"/></svg></div><div class="menu-copy"><strong>Inbox และดีล</strong><span>ดูดีลที่ต้องตัดสินใจและแชททั้งหมด</span></div><div class="menu-right"><svg><use href="#i-arrow"/></svg></div></div>
           <div class="menu-item"><div class="menu-icon"><svg><use href="#i-credit"/></svg></div><div class="menu-copy"><strong>เครดิต</strong><span>ยอดคงเหลือ ประวัติ และสถานะเครดิตของบัญชี</span></div><div class="menu-right"><svg><use href="#i-arrow"/></svg></div></div>
         </div>
+        <div class="menu-group-title" style="margin-top:18px">บัญชี</div>
+        <button class="logout-btn" onclick="closeProfileSettings(); signOut()">ออกจากระบบ</button>
       </div>
     </div>
 
@@ -4835,6 +4875,55 @@ function renderFeed(){
       go('feed');
     }
 
+    let loginTab = 'signin';
+
+    function setLoginTab(tab){
+      loginTab = tab;
+      document.getElementById('loginTabSignin')?.classList.toggle('active', tab === 'signin');
+      document.getElementById('loginTabSignup')?.classList.toggle('active', tab === 'signup');
+      const btn = document.getElementById('loginSubmitBtn');
+      if(btn) btn.textContent = tab === 'signin' ? 'เข้าสู่ระบบ' : 'สมัครสมาชิก';
+      const errEl = document.getElementById('loginError');
+      if(errEl) errEl.style.display = 'none';
+    }
+
+    async function submitLogin(){
+      const email = (document.getElementById('loginEmail')?.value || '').trim();
+      const password = document.getElementById('loginPassword')?.value || '';
+      const errEl = document.getElementById('loginError');
+      const btn = document.getElementById('loginSubmitBtn');
+      if(!email || !password){
+        if(errEl){ errEl.textContent = 'กรุณากรอกอีเมลและรหัสผ่าน'; errEl.style.display = 'block'; }
+        return;
+      }
+      if(btn){ btn.disabled = true; btn.textContent = 'กำลังดำเนินการ…'; }
+      if(errEl) errEl.style.display = 'none';
+      try {
+        const endpoint = loginTab === 'signup' ? '/auth/signup' : '/auth/signin';
+        const payload = await apiRequest(endpoint, {
+          method: 'POST',
+          body: JSON.stringify({ email, password }),
+        });
+        currentUser = payload?.user || null;
+        await hydrateFromApi(true);
+        rerenderDataDrivenSections();
+        syncDealUi();
+        go('feed', true);
+      } catch(err) {
+        if(errEl){ errEl.textContent = String(err?.message || 'เข้าสู่ระบบไม่สำเร็จ'); errEl.style.display = 'block'; }
+      } finally {
+        if(btn){ btn.disabled = false; btn.textContent = loginTab === 'signup' ? 'สมัครสมาชิก' : 'เข้าสู่ระบบ'; }
+      }
+    }
+
+    async function signOut(){
+      try { await apiRequest('/auth/signout', { method: 'POST' }); } catch {}
+      currentUser = null;
+      feedItems.splice(0, feedItems.length);
+      myInventory.splice(0, myInventory.length);
+      go('login', true);
+    }
+
     function openAddProductScreen(skipHistory=false){
       console.log('[add] click');
       if(!currentUser){
@@ -6457,6 +6546,18 @@ function renderFeed(){
 
     function go(target, skipHistory = false){
       const requested = String(target || 'feed');
+      if(requested === 'login'){
+        appState.screen = 'login';
+        document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
+        document.getElementById('screen-login')?.classList.add('active');
+        document.querySelector('.bottom-nav')?.style.setProperty('display','none');
+        return;
+      }
+      if(!currentUser && requested !== 'login'){
+        go('login', true);
+        return;
+      }
+      document.querySelector('.bottom-nav')?.style.removeProperty('display');
       const safeTarget = document.getElementById('screen-' + requested) ? requested : 'feed';
       if(requested === 'add'){
         openAddProductScreen(skipHistory);
@@ -6701,6 +6802,10 @@ function renderFeed(){
 
     hydrateFromApi(true)
       .then(() => {
+        if(!currentUser){
+          go('login', true);
+          return;
+        }
         rerenderDataDrivenSections();
         if(apiHydrationError){
           showToast(apiHydrationError);
@@ -6708,6 +6813,10 @@ function renderFeed(){
         syncDealUi();
       })
       .catch(() => {
+        if(!currentUser){
+          go('login', true);
+          return;
+        }
         rerenderDataDrivenSections();
       });
   </script>


### PR DESCRIPTION
## Summary

- เพิ่มหน้า **Login / Signup** — ถ้ายังไม่ login จะเห็นแค่หน้านี้ ไม่สามารถเข้าหน้าอื่นได้เลย
- `go()` redirect ไป login อัตโนมัติถ้า `currentUser` เป็น null และซ่อน bottom nav
- Startup `hydrateFromApi` — ถ้า `/auth/me` ไม่มี session → redirect login ทันที
- เพิ่มฟังก์ชัน `signOut()` — call `POST /auth/signout`, เคลียร์ state, กลับ login screen
- เพิ่มปุ่ม **ออกจากระบบ** ในหน้า Profile Settings sheet
- Login form กด Enter ที่ช่อง password เพื่อ submit ได้
- Tab toggle ระหว่าง เข้าสู่ระบบ / สมัครสมาชิก

## Test plan

- [ ] เปิดแอปครั้งแรก (ไม่มี session) → เห็นหน้า Login เท่านั้น ไม่เห็น feed / nav bar
- [ ] กรอก email + password ผิด → เห็น error message ใต้ปุ่ม
- [ ] กรอกถูก → login สำเร็จ, เข้าหน้า feed, เห็น nav bar
- [ ] สมัครสมาชิก tab → กรอก email + password → สร้างบัญชีได้
- [ ] Profile → กดปุ่ม ⚙️ Settings → เห็นปุ่ม "ออกจากระบบ" → กด → กลับหน้า Login
- [ ] หลัง logout กด back browser → ไม่สามารถกลับเข้าแอปได้ (redirect login)

https://claude.ai/code/session_01KuxsH2oXscveFQSyhwdjwK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuxsH2oXscveFQSyhwdjwK)_