### PR TITLE
Fix login 404 by wiring web login to Supabase auth

### DIFF
--- a/artifacts/web-app/index.html
+++ b/artifacts/web-app/index.html
@@ -2641,7 +2641,6 @@ h1,h2,h3{font-weight:900;}
 
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
   <script>
     function getUiElement(id){
@@ -2652,7 +2651,7 @@ h1,h2,h3{font-weight:900;}
     const SUPABASE_URL = window.__SUPABASE_URL__ || 'https://cpradtvneftyeflwjvmx.supabase.co';
     const SUPABASE_ANON_KEY = window.__SUPABASE_ANON_KEY__ || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImNwcmFkdHZuZWZ0eWVmbHdqdm14Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzY2NzY4OTcsImV4cCI6MjA5MjI1Mjg5N30.RATKQm94K3gqW3ZuiYdYa-iWAoyCeX-jkxGol8mfmUg';
     const supabaseLib = window.supabase;
-    const supabase =
+    const supabaseClient =
       supabaseLib && typeof supabaseLib.createClient === 'function' && SUPABASE_URL && SUPABASE_ANON_KEY
         ? supabaseLib.createClient(SUPABASE_URL, SUPABASE_ANON_KEY)
         : null;
@@ -2662,10 +2661,10 @@ h1,h2,h3{font-weight:900;}
     let authSubmitInFlight = false;
 
     function getAuthClient(){
-      if(!supabase){
+      if(!supabaseClient){
         throw new Error('ไม่สามารถเชื่อมต่อ Supabase ได้');
       }
-      return supabase;
+      return supabaseClient;
     }
 
     async function getAuthSessionUser(){
@@ -2676,8 +2675,8 @@ h1,h2,h3{font-weight:900;}
     }
 
     function listenAuthState(){
-      if(!supabase) return;
-      supabase.auth.onAuthStateChange((_event, session) => {
+      if(!supabaseClient) return;
+      supabaseClient.auth.onAuthStateChange((_event, session) => {
         currentUser = session?.user || null;
       });
     }

--- a/artifacts/web-app/index.html
+++ b/artifacts/web-app/index.html
@@ -2641,15 +2641,46 @@ h1,h2,h3{font-weight:900;}
 
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
   <script>
     function getUiElement(id){
       return document.getElementById(id);
     }
 
     const API_BASE = '/api';
+    const SUPABASE_URL = window.__SUPABASE_URL__ || 'https://cpradtvneftyeflwjvmx.supabase.co';
+    const SUPABASE_ANON_KEY = window.__SUPABASE_ANON_KEY__ || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImNwcmFkdHZuZWZ0eWVmbHdqdm14Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzY2NzY4OTcsImV4cCI6MjA5MjI1Mjg5N30.RATKQm94K3gqW3ZuiYdYa-iWAoyCeX-jkxGol8mfmUg';
+    const supabaseLib = window.supabase;
+    const supabase =
+      supabaseLib && typeof supabaseLib.createClient === 'function' && SUPABASE_URL && SUPABASE_ANON_KEY
+        ? supabaseLib.createClient(SUPABASE_URL, SUPABASE_ANON_KEY)
+        : null;
     let currentUser = null;
     let apiHydrationError = '';
     const savedOfferByItemId = new Map();
+    let authSubmitInFlight = false;
+
+    function getAuthClient(){
+      if(!supabase){
+        throw new Error('ไม่สามารถเชื่อมต่อ Supabase ได้');
+      }
+      return supabase;
+    }
+
+    async function getAuthSessionUser(){
+      const authClient = getAuthClient();
+      const { data: { session }, error } = await authClient.auth.getSession();
+      if(error) throw error;
+      return session?.user || null;
+    }
+
+    function listenAuthState(){
+      if(!supabase) return;
+      supabase.auth.onAuthStateChange((_event, session) => {
+        currentUser = session?.user || null;
+      });
+    }
 
     async function apiRequest(path, options = {}){
       const response = await fetch(`${API_BASE}${path}`, {
@@ -3106,8 +3137,7 @@ h1,h2,h3{font-weight:900;}
       if(hydrateFromApi._running && !force) return;
       hydrateFromApi._running = true;
       try{
-        const mePayload = await apiRequest('/auth/me').catch(() => null);
-        currentUser = mePayload?.user || null;
+        currentUser = await getAuthSessionUser().catch(() => null);
         const itemPayload = await apiRequest('/items');
         const apiItems = Array.isArray(itemPayload?.items) ? itemPayload.items : [];
         const offerPayload = currentUser
@@ -4903,7 +4933,9 @@ function renderFeed(){
       if(errEl) errEl.style.display = 'none';
     }
 
-    async function submitLogin(){
+    async function submitLogin(event){
+      event?.preventDefault?.();
+      if(authSubmitInFlight) return;
       const email = (document.getElementById('loginEmail')?.value || '').trim();
       const password = document.getElementById('loginPassword')?.value || '';
       const errEl = document.getElementById('loginError');
@@ -4912,15 +4944,27 @@ function renderFeed(){
         if(errEl){ errEl.textContent = 'กรุณากรอกอีเมลและรหัสผ่าน'; errEl.style.display = 'block'; }
         return;
       }
+      authSubmitInFlight = true;
       if(btn){ btn.disabled = true; btn.textContent = 'กำลังดำเนินการ…'; }
       if(errEl) errEl.style.display = 'none';
       try {
-        const endpoint = loginTab === 'signup' ? '/auth/signup' : '/auth/signin';
-        const payload = await apiRequest(endpoint, {
-          method: 'POST',
-          body: JSON.stringify({ email, password }),
-        });
-        currentUser = payload?.user || null;
+        const authClient = getAuthClient();
+        if(loginTab === 'signup'){
+          const { data, error } = await authClient.auth.signUp({ email, password });
+          if(error) throw error;
+          if(data?.user?.identities?.length === 0){
+            throw new Error('อีเมลนี้มีในระบบแล้ว ให้กดเข้าสู่ระบบแทน');
+          }
+          setLoginTab('signin');
+          if(errEl){
+            errEl.textContent = 'สมัครสมาชิกสำเร็จแล้ว ลองเข้าสู่ระบบได้เลย';
+            errEl.style.display = 'block';
+          }
+          return;
+        }
+        const { data, error } = await authClient.auth.signInWithPassword({ email, password });
+        if(error) throw error;
+        currentUser = data?.user || null;
         await hydrateFromApi(true);
         rerenderDataDrivenSections();
         syncDealUi();
@@ -4928,12 +4972,16 @@ function renderFeed(){
       } catch(err) {
         if(errEl){ errEl.textContent = String(err?.message || 'เข้าสู่ระบบไม่สำเร็จ'); errEl.style.display = 'block'; }
       } finally {
+        authSubmitInFlight = false;
         if(btn){ btn.disabled = false; btn.textContent = loginTab === 'signup' ? 'สมัครสมาชิก' : 'เข้าสู่ระบบ'; }
       }
     }
 
     async function signOut(){
-      try { await apiRequest('/auth/signout', { method: 'POST' }); } catch {}
+      try {
+        const authClient = getAuthClient();
+        await authClient.auth.signOut();
+      } catch {}
       currentUser = null;
       feedItems.splice(0, feedItems.length);
       myInventory.splice(0, myInventory.length);
@@ -4943,9 +4991,9 @@ function renderFeed(){
     function openAddProductScreen(skipHistory=false){
       console.log('[add] click');
       if(!currentUser){
-        apiRequest('/auth/me').then(payload => {
-          if(payload?.user){
-            currentUser = payload.user;
+        getAuthSessionUser().then((user) => {
+          if(user){
+            currentUser = user;
             openAddProductScreen(skipHistory);
           } else {
             showToast('กรุณาเข้าสู่ระบบก่อนเพิ่มสินค้า');
@@ -6823,6 +6871,7 @@ function renderFeed(){
       setTimeout(() => splash.remove(), 320);
     }
 
+    listenAuthState();
     hydrateFromApi(true)
       .then(() => {
         dismissSplash();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace login submit flow in `artifacts/web-app/index.html` to use Supabase auth directly (`signInWithPassword`) instead of legacy `/api/auth/signin` endpoint calls.
- Restore auth state from `supabase.auth.getSession()` during hydration and keep `onAuthStateChange` listener in sync.
- Keep existing UI structure intact while adding minimal login guards (empty credentials + double submit lock) and redirecting to feed on success.
- Update signout and auth checks to read Supabase session so refresh persistence works.
- Fix runtime name collision by using a dedicated `supabaseClient` variable in the inline script.

## Validation
- Web app build succeeds.
- Manual browser test verifies empty-field guard, successful login redirect, and session persistence after refresh.

### Walkthrough artifacts
[login-supabase-session-persistence-demo.mp4](https://cursor.com/agents/bc-9b832cd9-ca03-41f6-b951-f851c56c6456/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin-supabase-session-persistence-demo.mp4)
[Login empty guard error](https://cursor.com/agents/bc-9b832cd9-ca03-41f6-b951-f851c56c6456/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin-empty-guard-error.webp)
[Login redirects to feed](https://cursor.com/agents/bc-9b832cd9-ca03-41f6-b951-f851c56c6456/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin-redirect-feed.webp)
[Session persists after refresh](https://cursor.com/agents/bc-9b832cd9-ca03-41f6-b951-f851c56c6456/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin-session-after-refresh.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b832cd9-ca03-41f6-b951-f851c56c6456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b832cd9-ca03-41f6-b951-f851c56c6456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

