### PR TITLE
Tasks 4, 11, 12, 13 — full profile + conversations + real-time chat

### DIFF
--- a/artifacts/web-app/index.html
+++ b/artifacts/web-app/index.html
@@ -2659,6 +2659,7 @@ h1,h2,h3{font-weight:900;}
     let apiHydrationError = '';
     const savedOfferByItemId = new Map();
     let authSubmitInFlight = false;
+    let chatSubscription = null;
 
     function getAuthClient(){
       if(!supabaseClient){
@@ -3188,11 +3189,21 @@ h1,h2,h3{font-weight:900;}
         if(currentUser?.id){
           const meLabel = profileMap.get(currentUser.id);
           if(meLabel) viewerName = meLabel;
+          const { data: selfProfile } = await supabaseClient
+            .from('profiles')
+            .select('display_name, username, avatar_url, bio, location, rating, total_swaps')
+            .eq('id', currentUser.id)
+            .maybeSingle();
+          const resolvedName = selfProfile?.display_name || selfProfile?.username || meLabel || currentUser.email || profileDirectory.self.name;
+          if(resolvedName) viewerName = resolvedName;
           profileDirectory.self = {
             ...profileDirectory.self,
-            name: meLabel || currentUser.email || profileDirectory.self.name,
-            handle: `@${(currentUser.email || '').split('@')[0].replace(/[^a-z0-9]+/gi,'').toLowerCase() || 'me'}`,
-            img: profileDirectory.self.img,
+            name: resolvedName,
+            handle: `@${selfProfile?.username || (currentUser.email || '').split('@')[0].replace(/[^a-z0-9]+/gi,'').toLowerCase() || 'me'}`,
+            img: selfProfile?.avatar_url || profileDirectory.self.img,
+            subtitle: selfProfile?.bio || profileDirectory.self.subtitle,
+            rating: selfProfile?.rating != null ? String(Number(selfProfile.rating).toFixed(1)) : profileDirectory.self.rating,
+            deals: selfProfile?.total_swaps != null ? String(selfProfile.total_swaps) : profileDirectory.self.deals,
             trust: 'บัญชียืนยันแล้ว',
           };
         }
@@ -3364,6 +3375,19 @@ h1,h2,h3{font-weight:900;}
 
         Object.keys(chatThreads).forEach((key) => delete chatThreads[key]);
         Object.assign(chatThreads, chatMap);
+
+        if(currentUser){
+          const { data: convsData } = await supabaseClient
+            .from('conversations')
+            .select('id, participant_a, participant_b')
+            .or(`participant_a.eq.${currentUser.id},participant_b.eq.${currentUser.id}`)
+            .order('last_at', { ascending: false });
+          (convsData || []).forEach(conv => {
+            const otherId = conv.participant_a === currentUser.id ? conv.participant_b : conv.participant_a;
+            const otherName = profileMap.get(otherId) || profileLabelFromId(otherId);
+            if(chatThreads[otherName]) chatThreads[otherName].conversationId = conv.id;
+          });
+        }
 
         if(typeof savedFeedItems !== 'undefined'){
           savedFeedItems.clear();
@@ -4097,6 +4121,44 @@ h1,h2,h3{font-weight:900;}
       return chatThreads[clean];
     }
 
+    async function loadChatMessages(name){
+      const thread = chatThreads[name];
+      if(!thread?.conversationId || !supabaseClient) return;
+      const { data: msgs } = await supabaseClient
+        .from('messages')
+        .select('sender_id, text, created_at')
+        .eq('conversation_id', thread.conversationId)
+        .order('created_at', { ascending: true })
+        .limit(50);
+      if(msgs && msgs.length > 0){
+        thread.messages = msgs.map(m => ({
+          side: m.sender_id === currentUser?.id ? 'self' : 'other',
+          text: m.text,
+          time: relativeTimeFromApi(m.created_at),
+        }));
+        renderChatScreen(thread);
+        const host = document.getElementById('chatThread');
+        if(host) host.scrollTop = host.scrollHeight;
+      }
+      if(chatSubscription) supabaseClient.removeChannel(chatSubscription);
+      chatSubscription = supabaseClient
+        .channel(`chat:${thread.conversationId}`)
+        .on('postgres_changes', {
+          event: 'INSERT', schema: 'public', table: 'messages',
+          filter: `conversation_id=eq.${thread.conversationId}`,
+        }, (payload) => {
+          const msg = payload.new;
+          if(!msg || msg.sender_id === currentUser?.id) return;
+          const t = chatThreads[appState.activeChatName];
+          if(!t || t.conversationId !== thread.conversationId) return;
+          t.messages.push({ side: 'other', text: msg.text, time: 'ตอนนี้' });
+          renderChatScreen(t);
+          const h = document.getElementById('chatThread');
+          if(h) h.scrollTop = h.scrollHeight;
+        })
+        .subscribe();
+    }
+
     function openChatByName(name){
       console.log('[chat] open', name);
       const thread = ensureChatThreadForProfile(name);
@@ -4105,6 +4167,7 @@ h1,h2,h3{font-weight:900;}
       appState.activeChatName = thread.name;
       renderChatScreen(thread);
       go('chat');
+      loadChatMessages(name);
     }
 
     function renderChat(name){
@@ -4250,7 +4313,16 @@ h1,h2,h3{font-weight:900;}
       renderChatScreen(thread);
       const host = document.getElementById('chatThread');
       if(host) host.scrollTop = host.scrollHeight;
-      showToast('ส่งข้อความแล้ว');
+      if(thread.conversationId && currentUser?.id && supabaseClient){
+        supabaseClient.from('messages').insert({
+          conversation_id: thread.conversationId,
+          sender_id: currentUser.id,
+          text: value,
+        }).then(() => supabaseClient.from('conversations').update({
+          last_message: value,
+          last_at: new Date().toISOString(),
+        }).eq('id', thread.conversationId)).catch(() => showToast('ส่งข้อความไม่สำเร็จ'));
+      }
     }
 
     function renderStories(){
@@ -5810,7 +5882,18 @@ function renderFeed(){
           .from('offers')
           .update({ status: nextStatus })
           .eq('id', request.offerId)
-          .then(() => hydrateFromApi(true))
+          .then(async () => {
+            if(nextStatus === 'accepted' && request.senderId && currentUser?.id){
+              const [pA, pB] = [currentUser.id, request.senderId].sort();
+              await supabaseClient.from('conversations').upsert({
+                offer_id: request.offerId,
+                participant_a: pA,
+                participant_b: pB,
+                last_message: '',
+              }, { onConflict: 'offer_id' }).catch(() => {});
+            }
+            return hydrateFromApi(true);
+          })
           .then(() => syncDealUi())
           .catch(() => {});
       }


### PR DESCRIPTION
## What changed

**Task 4 — Real profile data**
- After login, fetches `display_name`, `username`, `avatar_url`, `bio`, `rating`, `total_swaps` from `profiles` table
- Profile screen now shows real name, avatar, and stats instead of mock data

**Task 11 — Create conversation on accept**
- When receiver accepts an offer, a `conversations` row is upserted in Supabase
- Both parties are set as `participant_a` / `participant_b` (sorted by UUID for uniqueness)

**Task 12 — Load conversations**
- `hydrateFromApi` now fetches all conversations for current user
- Maps each conversation to the correct `chatThreads[name].conversationId`

**Task 13 — Real-time chat**
- `loadChatMessages(name)` loads last 50 messages from `messages` table
- Subscribes to Supabase Realtime `INSERT` events — incoming messages appear instantly
- `sendChatMessage()` persists to `messages` table and updates `conversations.last_message`

## Tasks already done before this PR
- Task 2 (Login), Task 3 (Signup), Task 5 (Load items), Task 6 (Selection), Task 7 (Create offer), Task 8/9 (Load offers), Task 10 (Update status), Task 15 (GitHub Pages)

https://claude.ai/code/session_01KuxsH2oXscveFQSyhwdjwK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuxsH2oXscveFQSyhwdjwK)_