### PR TITLE
Backend: offers module, wallet system, product locking

### DIFF
--- a/artifacts/api-server/src/lib/errors.ts
+++ b/artifacts/api-server/src/lib/errors.ts
@@ -1,0 +1,10 @@
+export class AppError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AppError";
+  }
+}

--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -9,6 +9,7 @@ import chatRouter from "./chat";
 import bookmarksRouter from "./bookmarks";
 import dealsRouter from "./deals";
 import notificationsRouter from "./notifications";
+import walletRouter from "./wallet";
 
 const router: IRouter = Router();
 
@@ -22,5 +23,6 @@ router.use(bookmarksRouter);
 router.use(dealsRouter);
 router.use(chatRouter);
 router.use(notificationsRouter);
+router.use(walletRouter);
 
 export default router;

--- a/artifacts/api-server/src/routes/offers.ts
+++ b/artifacts/api-server/src/routes/offers.ts
@@ -1,115 +1,90 @@
 import { Router, type IRouter, type Request, type Response } from "express";
-import {
-  conversationsTable,
-  db,
-  dealsTable,
-  itemsTable,
-  notificationsTable,
-  offersTable,
-} from "@workspace/db";
-import { and, desc, eq, or } from "drizzle-orm";
 import { z } from "zod/v4";
 import { requireAuth } from "../middlewares/authMiddleware";
 import { sendError, sendValidationError } from "../lib/http";
+import { AppError } from "../lib/errors";
+import * as OfferService from "../services/offer.service";
 
 const router: IRouter = Router();
-const offerIdParamSchema = z.object({
-  id: z.uuid(),
-});
 
-const ACTIVE_OFFER_STATUSES = ["pending"] as const;
-const OFFER_TRANSITIONS = {
-  pending: ["accepted", "rejected", "canceled"],
-  accepted: [],
-  rejected: [],
-  canceled: [],
-} as const;
+// ─── Shared helpers ──────────────────────────────────────────
 
-type OfferListScope = "mine" | "sent" | "received";
-type OfferUpdateStatus = "accepted" | "rejected" | "canceled";
-
-async function listOffersForUser(userId: string, scope: OfferListScope) {
-  const whereClause =
-    scope === "sent"
-      ? eq(offersTable.senderId, userId)
-      : scope === "received"
-        ? eq(offersTable.receiverId, userId)
-        : or(eq(offersTable.senderId, userId), eq(offersTable.receiverId, userId));
-
-  const rows = await db
-    .select({
-      offer: offersTable,
-      itemId: itemsTable.id,
-      itemOwnerId: itemsTable.ownerId,
-      itemTitle: itemsTable.title,
-      itemStatus: itemsTable.status,
-      dealId: dealsTable.id,
-      dealStage: dealsTable.stage,
-      dealFulfillmentType: dealsTable.fulfillmentType,
-      dealLogisticsConfirmed: dealsTable.logisticsConfirmed,
-    })
-    .from(offersTable)
-    .leftJoin(itemsTable, eq(offersTable.targetItemId, itemsTable.id))
-    .leftJoin(dealsTable, eq(dealsTable.offerId, offersTable.id))
-    .where(whereClause)
-    .orderBy(desc(offersTable.createdAt));
-
-  return rows.map((row) => ({
-    ...row.offer,
-    item: row.itemId
-      ? {
-          id: row.itemId,
-          ownerId: row.itemOwnerId,
-          title: row.itemTitle,
-          status: row.itemStatus,
-        }
-      : null,
-    deal: row.dealId
-      ? {
-          id: row.dealId,
-          stage: row.dealStage,
-          fulfillmentType: row.dealFulfillmentType,
-          logisticsConfirmed: row.dealLogisticsConfirmed,
-        }
-      : null,
-  }));
+function handleError(res: Response, err: unknown) {
+  if (err instanceof AppError) {
+    sendError(res, err.statusCode, err.code, err.message);
+    return;
+  }
+  throw err; // re-throw so global error handler catches it
 }
 
-async function sendOfferList(
-  req: Request,
-  res: Response,
-  scope: OfferListScope,
-) {
-  if (!req.isAuthenticated()) return;
-  const offers = await listOffersForUser(req.user.id, scope);
-  res.json({ offers });
-}
+const offerIdSchema = z.object({ id: z.uuid() });
+
+// ─── GET /offers  (all mine) ─────────────────────────────────
 
 router.get("/offers", requireAuth, async (req: Request, res: Response) => {
-  await sendOfferList(req, res, "mine");
+  if (!req.isAuthenticated()) return;
+  const rows = await OfferService.listOffers(req.user.id, "mine");
+  res.json({ offers: rows });
 });
 
-router.get("/offers/mine", requireAuth, async (req: Request, res: Response) => {
-  await sendOfferList(req, res, "mine");
-});
-
-router.get("/offers/sent", requireAuth, async (req: Request, res: Response) => {
-  await sendOfferList(req, res, "sent");
-});
+router.get(
+  "/offers/sent",
+  requireAuth,
+  async (req: Request, res: Response) => {
+    if (!req.isAuthenticated()) return;
+    const rows = await OfferService.listOffers(req.user.id, "sent");
+    res.json({ offers: rows });
+  },
+);
 
 router.get(
   "/offers/received",
   requireAuth,
   async (req: Request, res: Response) => {
-    await sendOfferList(req, res, "received");
+    if (!req.isAuthenticated()) return;
+    const rows = await OfferService.listOffers(req.user.id, "received");
+    res.json({ offers: rows });
   },
 );
+
+// ─── GET /offers/:id ─────────────────────────────────────────
+
+router.get(
+  "/offers/:id",
+  requireAuth,
+  async (req: Request, res: Response) => {
+    if (!req.isAuthenticated()) return;
+    const p = offerIdSchema.safeParse(req.params);
+    if (!p.success) {
+      sendValidationError(res, "รหัสข้อเสนอไม่ถูกต้อง", p.error);
+      return;
+    }
+    try {
+      const offer = await OfferService.getOffer(p.data.id, req.user.id);
+      res.json({ offer });
+    } catch (err) {
+      handleError(res, err);
+    }
+  },
+);
+
+// ─── POST /offers ────────────────────────────────────────────
+
+const offerItemSchema = z
+  .object({
+    productId: z.uuid().optional(),
+    cashAmount: z.number().min(0).default(0),
+    creditAmount: z.number().min(0).default(0),
+  })
+  .refine(
+    (v) => v.productId !== undefined || v.cashAmount > 0 || v.creditAmount > 0,
+    { message: "แต่ละรายการต้องระบุสินค้า เงินสด หรือเครดิตอย่างน้อยหนึ่งอย่าง" },
+  );
 
 const createOfferSchema = z.object({
   targetItemId: z.uuid(),
   message: z.string().max(2000).optional(),
-  offeredCash: z.number().int().min(0).optional().default(0),
-  offeredCredit: z.number().int().min(0).optional().default(0),
+  items: z.array(offerItemSchema).min(1),
 });
 
 router.post("/offers", requireAuth, async (req: Request, res: Response) => {
@@ -119,240 +94,95 @@ router.post("/offers", requireAuth, async (req: Request, res: Response) => {
     sendValidationError(res, "ข้อมูลข้อเสนอไม่ครบ", parsed.error);
     return;
   }
-  const [item] = await db
-    .select()
-    .from(itemsTable)
-    .where(eq(itemsTable.id, parsed.data.targetItemId));
-  if (!item) {
-    sendError(res, 404, "not_found", "ไม่พบสินค้า");
-    return;
+  try {
+    const offer = await OfferService.createOffer(req.user.id, parsed.data);
+    res.status(201).json({ offer });
+  } catch (err) {
+    handleError(res, err);
   }
-  if (item.ownerId === req.user.id) {
-    sendError(res, 400, "invalid_state", "ไม่สามารถขอแลกสินค้าของตัวเอง");
-    return;
-  }
-  if (item.status !== "active") {
-    sendError(res, 409, "invalid_state", "ไม่สามารถส่งข้อเสนอให้สินค้าที่ไม่พร้อมแลก");
-    return;
-  }
-  const [existingActiveOffer] = await db
-    .select()
-    .from(offersTable)
-    .where(
-      and(
-        eq(offersTable.targetItemId, item.id),
-        eq(offersTable.senderId, req.user.id),
-        eq(offersTable.receiverId, item.ownerId),
-        eq(offersTable.status, ACTIVE_OFFER_STATUSES[0]),
-      ),
-    );
-  if (existingActiveOffer) {
-    sendError(
-      res,
-      409,
-      "conflict",
-      "คุณมีข้อเสนอที่รอดำเนินการสำหรับสินค้านี้อยู่แล้ว",
-    );
-    return;
-  }
-
-  const created = await db.transaction(async (tx) => {
-    const [newOffer] = await tx
-      .insert(offersTable)
-      .values({
-        targetItemId: parsed.data.targetItemId,
-        senderId: req.user.id,
-        receiverId: item.ownerId,
-        message: parsed.data.message ?? "",
-        offeredCash: parsed.data.offeredCash,
-        offeredCredit: parsed.data.offeredCredit,
-      })
-      .returning();
-
-    await tx.insert(notificationsTable).values({
-      userId: item.ownerId,
-      actorId: req.user.id,
-      type: "offer_received",
-      title: "คุณได้รับข้อเสนอใหม่",
-      body: item.title,
-      offerId: newOffer.id,
-    });
-
-    return newOffer;
-  });
-
-  res.status(201).json({ offer: created });
 });
 
-const patchSchema = z.object({
-  status: z.enum(["accepted", "rejected", "canceled"]),
-});
+// ─── POST /offers/:id/accept ─────────────────────────────────
 
-function canTransitionOffer(
-  currentStatus: keyof typeof OFFER_TRANSITIONS,
-  nextStatus: OfferUpdateStatus,
-) {
-  const allowedTransitions = OFFER_TRANSITIONS[
-    currentStatus
-  ] as readonly OfferUpdateStatus[];
-  return allowedTransitions.includes(nextStatus);
-}
-
-router.patch(
-  "/offers/:id",
+router.post(
+  "/offers/:id/accept",
   requireAuth,
   async (req: Request, res: Response) => {
     if (!req.isAuthenticated()) return;
-    const paramsParsed = offerIdParamSchema.safeParse(req.params);
-    if (!paramsParsed.success) {
-      sendValidationError(res, "รหัสข้อเสนอไม่ถูกต้อง", paramsParsed.error);
+    const p = offerIdSchema.safeParse(req.params);
+    if (!p.success) {
+      sendValidationError(res, "รหัสข้อเสนอไม่ถูกต้อง", p.error);
       return;
     }
-    const parsed = patchSchema.safeParse(req.body);
-    if (!parsed.success) {
-      sendValidationError(res, "status ไม่ถูกต้อง", parsed.error);
+    try {
+      const offer = await OfferService.acceptOffer(p.data.id, req.user.id);
+      res.json({ offer });
+    } catch (err) {
+      handleError(res, err);
+    }
+  },
+);
+
+// ─── POST /offers/:id/reject ─────────────────────────────────
+
+router.post(
+  "/offers/:id/reject",
+  requireAuth,
+  async (req: Request, res: Response) => {
+    if (!req.isAuthenticated()) return;
+    const p = offerIdSchema.safeParse(req.params);
+    if (!p.success) {
+      sendValidationError(res, "รหัสข้อเสนอไม่ถูกต้อง", p.error);
       return;
     }
-    const [offer] = await db
-      .select()
-      .from(offersTable)
-      .where(eq(offersTable.id, paramsParsed.data.id));
-    if (!offer) {
-      sendError(res, 404, "not_found", "ไม่พบข้อเสนอ");
+    try {
+      const offer = await OfferService.rejectOffer(p.data.id, req.user.id);
+      res.json({ offer });
+    } catch (err) {
+      handleError(res, err);
+    }
+  },
+);
+
+// ─── POST /offers/:id/cancel ─────────────────────────────────
+
+router.post(
+  "/offers/:id/cancel",
+  requireAuth,
+  async (req: Request, res: Response) => {
+    if (!req.isAuthenticated()) return;
+    const p = offerIdSchema.safeParse(req.params);
+    if (!p.success) {
+      sendValidationError(res, "รหัสข้อเสนอไม่ถูกต้อง", p.error);
       return;
     }
-    const [item] = await db
-      .select()
-      .from(itemsTable)
-      .where(eq(itemsTable.id, offer.targetItemId));
-    if (!item) {
-      sendError(res, 404, "not_found", "ไม่พบสินค้า");
+    try {
+      const offer = await OfferService.cancelOffer(p.data.id, req.user.id);
+      res.json({ offer });
+    } catch (err) {
+      handleError(res, err);
+    }
+  },
+);
+
+// ─── POST /offers/:id/confirm ────────────────────────────────
+
+router.post(
+  "/offers/:id/confirm",
+  requireAuth,
+  async (req: Request, res: Response) => {
+    if (!req.isAuthenticated()) return;
+    const p = offerIdSchema.safeParse(req.params);
+    if (!p.success) {
+      sendValidationError(res, "รหัสข้อเสนอไม่ถูกต้อง", p.error);
       return;
     }
-    const isReceiver = offer.receiverId === req.user.id;
-    const isSender = offer.senderId === req.user.id;
-    if (parsed.data.status === "canceled" && !isSender) {
-      sendError(res, 403, "forbidden", "เฉพาะผู้ส่งเท่านั้นที่ยกเลิกได้");
-      return;
+    try {
+      const result = await OfferService.confirmOffer(p.data.id, req.user.id);
+      res.json(result);
+    } catch (err) {
+      handleError(res, err);
     }
-    if (parsed.data.status !== "canceled" && !isReceiver) {
-      sendError(res, 403, "forbidden", "เฉพาะผู้รับข้อเสนอเท่านั้นที่ตอบได้");
-      return;
-    }
-    if (!canTransitionOffer(offer.status, parsed.data.status)) {
-      sendError(
-        res,
-        409,
-        "invalid_state",
-        "สถานะข้อเสนอไม่สามารถเปลี่ยนไปสถานะที่ต้องการได้",
-      );
-      return;
-    }
-    if (parsed.data.status === "accepted" && item.status !== "active") {
-      sendError(
-        res,
-        409,
-        "invalid_state",
-        "ไม่สามารถตอบรับข้อเสนอของสินค้าที่ไม่พร้อมแลก",
-      );
-      return;
-    }
-
-    const updated = await db.transaction(async (tx) => {
-      const [nextOffer] = await tx
-        .update(offersTable)
-        .set({ status: parsed.data.status })
-        .where(
-          and(
-            eq(offersTable.id, offer.id),
-            eq(offersTable.status, offer.status),
-          ),
-        )
-        .returning();
-
-      if (!nextOffer) {
-        return null;
-      }
-
-      if (parsed.data.status === "accepted") {
-        const updatedDeals = await tx
-          .update(dealsTable)
-          .set({
-            senderId: offer.senderId,
-            receiverId: offer.receiverId,
-            targetItemId: offer.targetItemId,
-            stage: "accepted",
-          })
-          .where(eq(dealsTable.offerId, offer.id))
-          .returning();
-
-        const [deal] =
-          updatedDeals.length > 0
-            ? updatedDeals
-            : await tx
-                .insert(dealsTable)
-                .values({
-                  offerId: offer.id,
-                  senderId: offer.senderId,
-                  receiverId: offer.receiverId,
-                  targetItemId: offer.targetItemId,
-                  stage: "accepted",
-                })
-                .returning();
-
-        const [participantAId, participantBId] = [
-          offer.senderId,
-          offer.receiverId,
-        ].sort();
-
-        const [existingConversation] = await tx
-          .select()
-          .from(conversationsTable)
-          .where(eq(conversationsTable.dealId, deal.id));
-
-        if (!existingConversation) {
-          await tx.insert(conversationsTable).values({
-            dealId: deal.id,
-            participantAId,
-            participantBId,
-            lastMessage: "",
-          });
-        }
-
-        await tx.insert(notificationsTable).values({
-          userId: offer.senderId,
-          actorId: req.user.id,
-          type: "offer_accepted",
-          title: "ข้อเสนอของคุณถูกตอบรับ",
-          offerId: offer.id,
-          dealId: deal.id,
-        });
-      }
-
-      if (parsed.data.status === "rejected") {
-        await tx.insert(notificationsTable).values({
-          userId: offer.senderId,
-          actorId: req.user.id,
-          type: "offer_rejected",
-          title: "ข้อเสนอของคุณถูกปฏิเสธ",
-          offerId: offer.id,
-        });
-      }
-
-      return nextOffer;
-    });
-
-    if (!updated) {
-      sendError(
-        res,
-        409,
-        "conflict",
-        "ข้อเสนอนี้ถูกอัปเดตไปแล้ว กรุณารีเฟรชแล้วลองใหม่",
-      );
-      return;
-    }
-
-    res.json({ offer: updated });
   },
 );
 

--- a/artifacts/api-server/src/routes/wallet.ts
+++ b/artifacts/api-server/src/routes/wallet.ts
@@ -1,0 +1,107 @@
+import { Router, type IRouter, type Request, type Response } from "express";
+import { db } from "@workspace/db";
+import { z } from "zod/v4";
+import { requireAuth } from "../middlewares/authMiddleware";
+import { sendError, sendValidationError } from "../lib/http";
+import { AppError } from "../lib/errors";
+import * as WalletService from "../services/wallet.service";
+
+const router: IRouter = Router();
+
+// ─── GET /wallet ─────────────────────────────────────────────
+// Returns the authenticated user's wallet (auto-creates if absent)
+
+router.get("/wallet", requireAuth, async (req: Request, res: Response) => {
+  if (!req.isAuthenticated()) return;
+  const wallet = await WalletService.getOrCreateWallet(db, req.user.id);
+  res.json({ wallet });
+});
+
+// ─── GET /transactions ───────────────────────────────────────
+// Query params: currency, type, offer_id, limit, offset
+
+const listQuerySchema = z.object({
+  currency: z.enum(["cash", "credit"]).optional(),
+  type: z.enum(["lock", "transfer", "refund"]).optional(),
+  offer_id: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+router.get(
+  "/transactions",
+  requireAuth,
+  async (req: Request, res: Response) => {
+    if (!req.isAuthenticated()) return;
+
+    const parsed = listQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      sendValidationError(res, "query ไม่ถูกต้อง", parsed.error);
+      return;
+    }
+
+    const { currency, type, offer_id, limit, offset } = parsed.data;
+
+    const transactions = await WalletService.listTransactions(req.user.id, {
+      currency,
+      type,
+      offerId: offer_id,
+      limit,
+      offset,
+    });
+
+    res.json({ transactions });
+  },
+);
+
+// ─── POST /wallet/deposit ────────────────────────────────────
+// Add funds to the authenticated user's wallet.
+// In production this would be gated behind a payment provider webhook;
+// for now it is an open endpoint for development / testing.
+
+const depositSchema = z.object({
+  cashAmount: z.number().min(0).default(0),
+  creditAmount: z.number().min(0).default(0),
+  note: z.string().max(255).optional(),
+});
+
+router.post(
+  "/wallet/deposit",
+  requireAuth,
+  async (req: Request, res: Response) => {
+    if (!req.isAuthenticated()) return;
+
+    const parsed = depositSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendValidationError(res, "ข้อมูลการฝากเงินไม่ถูกต้อง", parsed.error);
+      return;
+    }
+
+    const { cashAmount, creditAmount, note } = parsed.data;
+
+    if (cashAmount === 0 && creditAmount === 0) {
+      sendError(res, 400, "bad_request", "ต้องระบุจำนวนเงินที่จะฝากอย่างน้อยหนึ่งอย่าง");
+      return;
+    }
+
+    try {
+      const wallet = await db.transaction((tx) =>
+        WalletService.deposit(tx, {
+          userId: req.user!.id,
+          cashAmount,
+          creditAmount,
+          note,
+        }),
+      );
+      res.json({ wallet });
+    } catch (err) {
+      if (err instanceof AppError) {
+        sendError(res, err.statusCode, err.code, err.message);
+        return;
+      }
+      throw err;
+    }
+  },
+);
+
+export default router;

--- a/artifacts/api-server/src/services/notification.service.ts
+++ b/artifacts/api-server/src/services/notification.service.ts
@@ -1,0 +1,30 @@
+import { db, notificationsTable } from "@workspace/db";
+import type { notificationTypeEnum } from "@workspace/db";
+
+type DbOrTx =
+  | typeof db
+  | Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+type NotificationType = (typeof notificationTypeEnum.enumValues)[number];
+
+interface NotifyParams {
+  userId: string;
+  actorId?: string;
+  type: NotificationType;
+  offerId?: string;
+  dealId?: string;
+  title: string;
+  body?: string;
+}
+
+export async function notify(tx: DbOrTx, params: NotifyParams) {
+  await tx.insert(notificationsTable).values({
+    userId: params.userId,
+    actorId: params.actorId ?? null,
+    type: params.type,
+    offerId: params.offerId ?? null,
+    dealId: params.dealId ?? null,
+    title: params.title,
+    body: params.body ?? null,
+  });
+}

--- a/artifacts/api-server/src/services/offer.service.ts
+++ b/artifacts/api-server/src/services/offer.service.ts
@@ -10,6 +10,7 @@ import { and, count, desc, eq, or } from "drizzle-orm";
 import { AppError } from "../lib/errors";
 import * as WalletService from "./wallet.service";
 import * as NotificationService from "./notification.service";
+import * as ProductService from "./product.service";
 
 type DbOrTx =
   | typeof db
@@ -94,11 +95,13 @@ export async function createOffer(fromUserId: string, input: CreateOfferInput) {
 
     if (!targetItem) throw new AppError(404, "not_found", "ไม่พบสินค้า");
     if (targetItem.ownerId === fromUserId) {
-      throw new AppError(
-        400,
-        "invalid_state",
-        "ไม่สามารถขอแลกสินค้าของตัวเอง",
-      );
+      throw new AppError(400, "invalid_state", "ไม่สามารถขอแลกสินค้าของตัวเอง");
+    }
+    if (targetItem.status === "locked") {
+      throw new AppError(409, "product_locked", "สินค้านี้กำลังอยู่ในระหว่างการแลกเปลี่ยนอื่น");
+    }
+    if (targetItem.status === "traded") {
+      throw new AppError(409, "product_traded", "สินค้านี้ถูกแลกเปลี่ยนไปแล้ว");
     }
     if (targetItem.status !== "active") {
       throw new AppError(409, "invalid_state", "สินค้าไม่พร้อมรับข้อเสนอ");
@@ -123,34 +126,12 @@ export async function createOffer(fromUserId: string, input: CreateOfferInput) {
       );
     }
 
-    // 3. Validate all offered products are owned + active
+    // 3. Validate all offered products: owned by sender, not locked, not traded
     const offeredProductIds = input.items
       .filter((i) => i.productId)
       .map((i) => i.productId as string);
 
-    for (const pid of offeredProductIds) {
-      const [product] = await tx
-        .select()
-        .from(itemsTable)
-        .where(eq(itemsTable.id, pid));
-      if (!product) {
-        throw new AppError(404, "not_found", `ไม่พบสินค้าที่ยื่นแลก: ${pid}`);
-      }
-      if (product.ownerId !== fromUserId) {
-        throw new AppError(
-          403,
-          "forbidden",
-          `สินค้า ${pid} ไม่ใช่ของคุณ`,
-        );
-      }
-      if (product.status !== "active") {
-        throw new AppError(
-          409,
-          "invalid_state",
-          `สินค้า ${pid} ไม่อยู่ในสถานะพร้อมแลก`,
-        );
-      }
-    }
+    await ProductService.validateProductsAvailable(tx, offeredProductIds, fromUserId);
 
     // 4. Aggregate totals for denormalised columns + wallet lock
     const totalCash = input.items.reduce(
@@ -197,13 +178,8 @@ export async function createOffer(fromUserId: string, input: CreateOfferInput) {
       });
     }
 
-    // 9. Lock offered products
-    for (const pid of offeredProductIds) {
-      await tx
-        .update(itemsTable)
-        .set({ status: "locked" })
-        .where(eq(itemsTable.id, pid));
-    }
+    // 9. Lock offered products (batch update)
+    await ProductService.lockProducts(tx, offeredProductIds);
 
     // 10. Auto-create chat room
     await tx.insert(offerChatsTable).values({ offerId: offer.id });
@@ -246,6 +222,9 @@ export async function acceptOffer(offerId: string, userId: string) {
         "ข้อเสนอถูกอัปเดตก่อนหน้านี้แล้ว กรุณารีเฟรช",
       );
     }
+
+    // Lock target item so it cannot receive new offers while deal is active
+    await ProductService.lockProducts(tx, [offer.targetItemId]);
 
     await NotificationService.notify(tx, {
       userId: offer.senderId,
@@ -412,22 +391,25 @@ function assertTransition(current: string, next: string) {
 }
 
 async function unlockOfferAssets(tx: DbOrTx, offer: OfferRow) {
-  // Unlock offered products
-  const items = await tx
-    .select()
+  // Unlock sender's offered products
+  const offerItems = await tx
+    .select({ productId: offerItemsTable.productId })
     .from(offerItemsTable)
-    .where(and(eq(offerItemsTable.offerId, offer.id)));
+    .where(eq(offerItemsTable.offerId, offer.id));
 
-  for (const item of items) {
-    if (item.productId) {
-      await tx
-        .update(itemsTable)
-        .set({ status: "active" })
-        .where(eq(itemsTable.id, item.productId));
-    }
+  const offeredProductIds = offerItems
+    .map((i) => i.productId)
+    .filter((id): id is string => id !== null);
+
+  await ProductService.unlockProducts(tx, offeredProductIds);
+
+  // Target item is only locked after offer is accepted.
+  // If we are cancelling from "accepted" state, unlock it too.
+  if (offer.status === "accepted") {
+    await ProductService.unlockProducts(tx, [offer.targetItemId]);
   }
 
-  // Refund locked funds
+  // Refund locked funds to sender
   await WalletService.releaseFunds(tx, {
     userId: offer.senderId,
     offerId: offer.id,
@@ -435,26 +417,20 @@ async function unlockOfferAssets(tx: DbOrTx, offer: OfferRow) {
 }
 
 async function completeTrade(tx: DbOrTx, offer: OfferRow) {
-  // 1. Transfer offered products to receiver
-  const items = await tx
-    .select()
+  // 1. Transfer sender's offered products → receiver
+  const offerItems = await tx
+    .select({ productId: offerItemsTable.productId })
     .from(offerItemsTable)
     .where(eq(offerItemsTable.offerId, offer.id));
 
-  for (const item of items) {
-    if (item.productId) {
-      await tx
-        .update(itemsTable)
-        .set({ status: "traded", ownerId: offer.receiverId })
-        .where(eq(itemsTable.id, item.productId));
-    }
-  }
+  const offeredProductIds = offerItems
+    .map((i) => i.productId)
+    .filter((id): id is string => id !== null);
 
-  // 2. Transfer target item to sender
-  await tx
-    .update(itemsTable)
-    .set({ status: "traded", ownerId: offer.senderId })
-    .where(eq(itemsTable.id, offer.targetItemId));
+  await ProductService.tradeProducts(tx, offeredProductIds, offer.receiverId);
+
+  // 2. Transfer target item → sender
+  await ProductService.tradeProducts(tx, [offer.targetItemId], offer.senderId);
 
   // 3. Transfer locked funds to receiver
   await WalletService.transferFunds(tx, {

--- a/artifacts/api-server/src/services/offer.service.ts
+++ b/artifacts/api-server/src/services/offer.service.ts
@@ -1,0 +1,490 @@
+import {
+  db,
+  itemsTable,
+  offerChatsTable,
+  offerConfirmationsTable,
+  offerItemsTable,
+  offersTable,
+} from "@workspace/db";
+import { and, count, desc, eq, or } from "drizzle-orm";
+import { AppError } from "../lib/errors";
+import * as WalletService from "./wallet.service";
+import * as NotificationService from "./notification.service";
+
+type DbOrTx =
+  | typeof db
+  | Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+// ─── Input types ─────────────────────────────────────────────
+
+export interface OfferItemInput {
+  productId?: string;
+  cashAmount?: number;
+  creditAmount?: number;
+}
+
+export interface CreateOfferInput {
+  targetItemId: string;
+  message?: string;
+  items: OfferItemInput[];
+}
+
+// ─── Queries ─────────────────────────────────────────────────
+
+export async function getOffer(offerId: string, requesterId: string) {
+  const [offer] = await db
+    .select()
+    .from(offersTable)
+    .where(eq(offersTable.id, offerId));
+
+  if (!offer) throw new AppError(404, "not_found", "ไม่พบข้อเสนอ");
+  if (offer.senderId !== requesterId && offer.receiverId !== requesterId) {
+    throw new AppError(403, "forbidden", "ไม่มีสิทธิ์เข้าถึงข้อเสนอนี้");
+  }
+
+  const items = await db
+    .select()
+    .from(offerItemsTable)
+    .where(eq(offerItemsTable.offerId, offerId));
+
+  const confirmations = await db
+    .select()
+    .from(offerConfirmationsTable)
+    .where(eq(offerConfirmationsTable.offerId, offerId));
+
+  return { ...offer, items, confirmations };
+}
+
+export async function listOffers(
+  userId: string,
+  scope: "mine" | "sent" | "received",
+) {
+  const where =
+    scope === "sent"
+      ? eq(offersTable.senderId, userId)
+      : scope === "received"
+        ? eq(offersTable.receiverId, userId)
+        : or(
+            eq(offersTable.senderId, userId),
+            eq(offersTable.receiverId, userId),
+          );
+
+  return db
+    .select({
+      offer: offersTable,
+      targetItemTitle: itemsTable.title,
+      targetItemStatus: itemsTable.status,
+      targetItemImageEmoji: itemsTable.imageEmoji,
+    })
+    .from(offersTable)
+    .leftJoin(itemsTable, eq(offersTable.targetItemId, itemsTable.id))
+    .where(where)
+    .orderBy(desc(offersTable.createdAt));
+}
+
+// ─── Create ───────────────────────────────────────────────────
+
+export async function createOffer(fromUserId: string, input: CreateOfferInput) {
+  return db.transaction(async (tx) => {
+    // 1. Validate target item
+    const [targetItem] = await tx
+      .select()
+      .from(itemsTable)
+      .where(eq(itemsTable.id, input.targetItemId));
+
+    if (!targetItem) throw new AppError(404, "not_found", "ไม่พบสินค้า");
+    if (targetItem.ownerId === fromUserId) {
+      throw new AppError(
+        400,
+        "invalid_state",
+        "ไม่สามารถขอแลกสินค้าของตัวเอง",
+      );
+    }
+    if (targetItem.status !== "active") {
+      throw new AppError(409, "invalid_state", "สินค้าไม่พร้อมรับข้อเสนอ");
+    }
+
+    // 2. No duplicate pending offer from same sender
+    const [duplicate] = await tx
+      .select({ id: offersTable.id })
+      .from(offersTable)
+      .where(
+        and(
+          eq(offersTable.targetItemId, input.targetItemId),
+          eq(offersTable.senderId, fromUserId),
+          eq(offersTable.status, "pending"),
+        ),
+      );
+    if (duplicate) {
+      throw new AppError(
+        409,
+        "conflict",
+        "มีข้อเสนอที่รอดำเนินการสำหรับสินค้านี้อยู่แล้ว",
+      );
+    }
+
+    // 3. Validate all offered products are owned + active
+    const offeredProductIds = input.items
+      .filter((i) => i.productId)
+      .map((i) => i.productId as string);
+
+    for (const pid of offeredProductIds) {
+      const [product] = await tx
+        .select()
+        .from(itemsTable)
+        .where(eq(itemsTable.id, pid));
+      if (!product) {
+        throw new AppError(404, "not_found", `ไม่พบสินค้าที่ยื่นแลก: ${pid}`);
+      }
+      if (product.ownerId !== fromUserId) {
+        throw new AppError(
+          403,
+          "forbidden",
+          `สินค้า ${pid} ไม่ใช่ของคุณ`,
+        );
+      }
+      if (product.status !== "active") {
+        throw new AppError(
+          409,
+          "invalid_state",
+          `สินค้า ${pid} ไม่อยู่ในสถานะพร้อมแลก`,
+        );
+      }
+    }
+
+    // 4. Aggregate totals for denormalised columns + wallet lock
+    const totalCash = input.items.reduce(
+      (s, i) => s + (i.cashAmount ?? 0),
+      0,
+    );
+    const totalCredit = input.items.reduce(
+      (s, i) => s + (i.creditAmount ?? 0),
+      0,
+    );
+
+    // 5. Ensure sender wallet exists (balance check happens in lockFunds)
+    await WalletService.getOrCreateWallet(tx, fromUserId);
+
+    // 6. Insert offer first to get a real ID
+    const [offer] = await tx
+      .insert(offersTable)
+      .values({
+        targetItemId: input.targetItemId,
+        senderId: fromUserId,
+        receiverId: targetItem.ownerId,
+        message: input.message ?? "",
+        offeredCash: String(totalCash),
+        offeredCredit: String(totalCredit),
+        status: "pending",
+      })
+      .returning();
+
+    // 7. Lock funds using the real offerId
+    await WalletService.lockFunds(tx, {
+      userId: fromUserId,
+      offerId: offer.id,
+      cashAmount: totalCash,
+      creditAmount: totalCredit,
+    });
+
+    // 8. Insert offer_items
+    for (const item of input.items) {
+      await tx.insert(offerItemsTable).values({
+        offerId: offer.id,
+        productId: item.productId ?? null,
+        cashAmount: String(item.cashAmount ?? 0),
+        creditAmount: String(item.creditAmount ?? 0),
+      });
+    }
+
+    // 9. Lock offered products
+    for (const pid of offeredProductIds) {
+      await tx
+        .update(itemsTable)
+        .set({ status: "locked" })
+        .where(eq(itemsTable.id, pid));
+    }
+
+    // 10. Auto-create chat room
+    await tx.insert(offerChatsTable).values({ offerId: offer.id });
+
+    // 11. Notify receiver
+    await NotificationService.notify(tx, {
+      userId: targetItem.ownerId,
+      actorId: fromUserId,
+      type: "offer_received",
+      offerId: offer.id,
+      title: "คุณได้รับข้อเสนอใหม่",
+      body: targetItem.title,
+    });
+
+    return offer;
+  });
+}
+
+// ─── Accept ──────────────────────────────────────────────────
+
+export async function acceptOffer(offerId: string, userId: string) {
+  return db.transaction(async (tx) => {
+    const offer = await lockOffer(tx, offerId);
+
+    if (offer.receiverId !== userId) {
+      throw new AppError(403, "forbidden", "เฉพาะผู้รับข้อเสนอเท่านั้นที่ตอบรับได้");
+    }
+    assertTransition(offer.status, "accepted");
+
+    const [updated] = await tx
+      .update(offersTable)
+      .set({ status: "accepted" })
+      .where(and(eq(offersTable.id, offerId), eq(offersTable.status, "pending")))
+      .returning();
+
+    if (!updated) {
+      throw new AppError(
+        409,
+        "conflict",
+        "ข้อเสนอถูกอัปเดตก่อนหน้านี้แล้ว กรุณารีเฟรช",
+      );
+    }
+
+    await NotificationService.notify(tx, {
+      userId: offer.senderId,
+      actorId: userId,
+      type: "offer_accepted",
+      offerId,
+      title: "ข้อเสนอของคุณถูกตอบรับ",
+    });
+
+    return updated;
+  });
+}
+
+// ─── Reject ──────────────────────────────────────────────────
+
+export async function rejectOffer(offerId: string, userId: string) {
+  return db.transaction(async (tx) => {
+    const offer = await lockOffer(tx, offerId);
+
+    if (offer.receiverId !== userId) {
+      throw new AppError(403, "forbidden", "เฉพาะผู้รับข้อเสนอเท่านั้นที่ปฏิเสธได้");
+    }
+    assertTransition(offer.status, "rejected");
+
+    const [updated] = await tx
+      .update(offersTable)
+      .set({ status: "rejected" })
+      .where(and(eq(offersTable.id, offerId), eq(offersTable.status, offer.status)))
+      .returning();
+
+    if (!updated) {
+      throw new AppError(409, "conflict", "ข้อเสนอถูกอัปเดตก่อนหน้านี้แล้ว กรุณารีเฟรช");
+    }
+
+    await unlockOfferAssets(tx, offer);
+
+    await NotificationService.notify(tx, {
+      userId: offer.senderId,
+      actorId: userId,
+      type: "offer_rejected",
+      offerId,
+      title: "ข้อเสนอของคุณถูกปฏิเสธ",
+    });
+
+    return updated;
+  });
+}
+
+// ─── Cancel ──────────────────────────────────────────────────
+
+export async function cancelOffer(offerId: string, userId: string) {
+  return db.transaction(async (tx) => {
+    const offer = await lockOffer(tx, offerId);
+
+    if (offer.senderId !== userId) {
+      throw new AppError(403, "forbidden", "เฉพาะผู้ส่งข้อเสนอเท่านั้นที่ยกเลิกได้");
+    }
+    assertTransition(offer.status, "canceled");
+
+    const [updated] = await tx
+      .update(offersTable)
+      .set({ status: "canceled" })
+      .where(and(eq(offersTable.id, offerId), eq(offersTable.status, offer.status)))
+      .returning();
+
+    if (!updated) {
+      throw new AppError(409, "conflict", "ข้อเสนอถูกอัปเดตก่อนหน้านี้แล้ว กรุณารีเฟรช");
+    }
+
+    await unlockOfferAssets(tx, offer);
+
+    await NotificationService.notify(tx, {
+      userId: offer.receiverId,
+      actorId: userId,
+      type: "offer_cancelled",
+      offerId,
+      title: "ข้อเสนอถูกยกเลิก",
+    });
+
+    return updated;
+  });
+}
+
+// ─── Confirm ─────────────────────────────────────────────────
+
+export async function confirmOffer(offerId: string, userId: string) {
+  return db.transaction(async (tx) => {
+    const offer = await lockOffer(tx, offerId);
+
+    if (offer.senderId !== userId && offer.receiverId !== userId) {
+      throw new AppError(403, "forbidden", "ไม่มีสิทธิ์ยืนยันข้อเสนอนี้");
+    }
+    if (offer.status !== "accepted") {
+      throw new AppError(
+        409,
+        "invalid_state",
+        "ยืนยันได้เฉพาะข้อเสนอที่ถูกตอบรับแล้ว",
+      );
+    }
+
+    // Insert confirmation — UNIQUE constraint prevents double-confirm
+    await tx
+      .insert(offerConfirmationsTable)
+      .values({ offerId, userId })
+      .onConflictDoNothing();
+
+    const [{ total }] = await tx
+      .select({ total: count() })
+      .from(offerConfirmationsTable)
+      .where(eq(offerConfirmationsTable.offerId, offerId));
+
+    const otherParty =
+      userId === offer.senderId ? offer.receiverId : offer.senderId;
+
+    await NotificationService.notify(tx, {
+      userId: otherParty,
+      actorId: userId,
+      type: "offer_confirmed",
+      offerId,
+      title: "อีกฝ่ายยืนยันแล้ว",
+    });
+
+    // Both sides confirmed → complete transaction
+    if (total >= 2) {
+      return completeTrade(tx, offer);
+    }
+
+    return { offer, bothConfirmed: false };
+  });
+}
+
+// ─── Internal helpers ─────────────────────────────────────────
+
+type OfferRow = typeof offersTable.$inferSelect;
+
+async function lockOffer(tx: DbOrTx, offerId: string): Promise<OfferRow> {
+  const [offer] = await tx
+    .select()
+    .from(offersTable)
+    .where(eq(offersTable.id, offerId))
+    .for("update");
+
+  if (!offer) throw new AppError(404, "not_found", "ไม่พบข้อเสนอ");
+  return offer;
+}
+
+const TRANSITIONS: Record<string, readonly string[]> = {
+  pending: ["accepted", "rejected", "canceled"],
+  accepted: ["canceled", "shipping"],
+  shipping: ["completed"],
+  rejected: [],
+  canceled: [],
+  completed: [],
+};
+
+function assertTransition(current: string, next: string) {
+  if (!TRANSITIONS[current]?.includes(next)) {
+    throw new AppError(
+      409,
+      "invalid_state",
+      `ไม่สามารถเปลี่ยนสถานะจาก ${current} → ${next}`,
+    );
+  }
+}
+
+async function unlockOfferAssets(tx: DbOrTx, offer: OfferRow) {
+  // Unlock offered products
+  const items = await tx
+    .select()
+    .from(offerItemsTable)
+    .where(and(eq(offerItemsTable.offerId, offer.id)));
+
+  for (const item of items) {
+    if (item.productId) {
+      await tx
+        .update(itemsTable)
+        .set({ status: "active" })
+        .where(eq(itemsTable.id, item.productId));
+    }
+  }
+
+  // Refund locked funds
+  await WalletService.releaseFunds(tx, {
+    userId: offer.senderId,
+    offerId: offer.id,
+  });
+}
+
+async function completeTrade(tx: DbOrTx, offer: OfferRow) {
+  // 1. Transfer offered products to receiver
+  const items = await tx
+    .select()
+    .from(offerItemsTable)
+    .where(eq(offerItemsTable.offerId, offer.id));
+
+  for (const item of items) {
+    if (item.productId) {
+      await tx
+        .update(itemsTable)
+        .set({ status: "traded", ownerId: offer.receiverId })
+        .where(eq(itemsTable.id, item.productId));
+    }
+  }
+
+  // 2. Transfer target item to sender
+  await tx
+    .update(itemsTable)
+    .set({ status: "traded", ownerId: offer.senderId })
+    .where(eq(itemsTable.id, offer.targetItemId));
+
+  // 3. Transfer locked funds to receiver
+  await WalletService.transferFunds(tx, {
+    fromUserId: offer.senderId,
+    toUserId: offer.receiverId,
+    offerId: offer.id,
+  });
+
+  // 4. Mark offer completed
+  const [updated] = await tx
+    .update(offersTable)
+    .set({ status: "completed" })
+    .where(eq(offersTable.id, offer.id))
+    .returning();
+
+  // 5. Notify both
+  await NotificationService.notify(tx, {
+    userId: offer.senderId,
+    actorId: offer.receiverId,
+    type: "offer_confirmed",
+    offerId: offer.id,
+    title: "การแลกเปลี่ยนสำเร็จแล้ว",
+  });
+  await NotificationService.notify(tx, {
+    userId: offer.receiverId,
+    actorId: offer.senderId,
+    type: "offer_confirmed",
+    offerId: offer.id,
+    title: "การแลกเปลี่ยนสำเร็จแล้ว",
+  });
+
+  return { offer: updated, bothConfirmed: true };
+}

--- a/artifacts/api-server/src/services/product.service.ts
+++ b/artifacts/api-server/src/services/product.service.ts
@@ -1,0 +1,116 @@
+import { db, itemsTable } from "@workspace/db";
+import { eq, inArray } from "drizzle-orm";
+import { AppError } from "../lib/errors";
+
+export type DbOrTx =
+  | typeof db
+  | Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/**
+ * Validates that every productId in the list:
+ *   - exists in the DB
+ *   - is owned by ownerId
+ *   - is in "active" status (gives a specific error for "locked")
+ *
+ * Call this inside a transaction before locking to ensure consistent reads.
+ */
+export async function validateProductsAvailable(
+  tx: DbOrTx,
+  productIds: string[],
+  ownerId: string,
+): Promise<void> {
+  if (productIds.length === 0) return;
+
+  for (const productId of productIds) {
+    const [product] = await tx
+      .select({
+        id: itemsTable.id,
+        title: itemsTable.title,
+        ownerId: itemsTable.ownerId,
+        status: itemsTable.status,
+      })
+      .from(itemsTable)
+      .where(eq(itemsTable.id, productId));
+
+    if (!product) {
+      throw new AppError(404, "not_found", `ไม่พบสินค้า: ${productId}`);
+    }
+    if (product.ownerId !== ownerId) {
+      throw new AppError(
+        403,
+        "forbidden",
+        `สินค้า "${product.title}" ไม่ใช่ของคุณ`,
+      );
+    }
+    if (product.status === "locked") {
+      throw new AppError(
+        409,
+        "product_locked",
+        `สินค้า "${product.title}" กำลังอยู่ในระหว่างการแลกเปลี่ยนอื่น`,
+      );
+    }
+    if (product.status === "traded") {
+      throw new AppError(
+        409,
+        "product_traded",
+        `สินค้า "${product.title}" ถูกแลกเปลี่ยนไปแล้ว`,
+      );
+    }
+    if (product.status !== "active") {
+      throw new AppError(
+        409,
+        "invalid_state",
+        `สินค้า "${product.title}" ไม่พร้อมสำหรับการแลกเปลี่ยน (สถานะ: ${product.status})`,
+      );
+    }
+  }
+}
+
+/**
+ * Sets all listed products to "locked".
+ * Uses a single UPDATE with IN clause for efficiency.
+ */
+export async function lockProducts(
+  tx: DbOrTx,
+  productIds: string[],
+): Promise<void> {
+  if (productIds.length === 0) return;
+
+  await tx
+    .update(itemsTable)
+    .set({ status: "locked" })
+    .where(inArray(itemsTable.id, productIds));
+}
+
+/**
+ * Restores all listed products back to "active".
+ * Called on offer reject or cancel.
+ */
+export async function unlockProducts(
+  tx: DbOrTx,
+  productIds: string[],
+): Promise<void> {
+  if (productIds.length === 0) return;
+
+  await tx
+    .update(itemsTable)
+    .set({ status: "active" })
+    .where(inArray(itemsTable.id, productIds));
+}
+
+/**
+ * Marks all listed products as "traded" and transfers ownership to newOwnerId.
+ * Called when both sides confirm and the trade completes.
+ */
+export async function tradeProducts(
+  tx: DbOrTx,
+  productIds: string[],
+  newOwnerId: string,
+): Promise<void> {
+  if (productIds.length === 0) return;
+
+  await tx
+    .update(itemsTable)
+    .set({ status: "traded", ownerId: newOwnerId })
+    .where(inArray(itemsTable.id, productIds));
+}

--- a/artifacts/api-server/src/services/wallet.service.ts
+++ b/artifacts/api-server/src/services/wallet.service.ts
@@ -1,10 +1,12 @@
 import { db, walletsTable, transactionsTable } from "@workspace/db";
-import { and, eq, sql } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 import { AppError } from "../lib/errors";
 
-type DbOrTx =
+export type DbOrTx =
   | typeof db
   | Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+// ─── Read ─────────────────────────────────────────────────────
 
 export async function getOrCreateWallet(tx: DbOrTx, userId: string) {
   const [existing] = await tx
@@ -19,6 +21,98 @@ export async function getOrCreateWallet(tx: DbOrTx, userId: string) {
     .values({ userId })
     .returning();
   return created;
+}
+
+export interface ListTransactionsFilters {
+  currency?: "cash" | "credit";
+  type?: "lock" | "transfer" | "refund";
+  offerId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export async function listTransactions(
+  userId: string,
+  filters: ListTransactionsFilters = {},
+) {
+  const conditions = [eq(transactionsTable.userId, userId)];
+
+  if (filters.currency) {
+    conditions.push(eq(transactionsTable.currency, filters.currency));
+  }
+  if (filters.type) {
+    conditions.push(eq(transactionsTable.type, filters.type));
+  }
+  if (filters.offerId) {
+    conditions.push(eq(transactionsTable.offerId, filters.offerId));
+  }
+
+  return db
+    .select()
+    .from(transactionsTable)
+    .where(and(...conditions))
+    .orderBy(desc(transactionsTable.createdAt))
+    .limit(Math.min(filters.limit ?? 50, 200))
+    .offset(filters.offset ?? 0);
+}
+
+// ─── Mutations ────────────────────────────────────────────────
+
+export async function deposit(
+  tx: DbOrTx,
+  {
+    userId,
+    cashAmount = 0,
+    creditAmount = 0,
+    note,
+  }: {
+    userId: string;
+    cashAmount?: number;
+    creditAmount?: number;
+    note?: string;
+  },
+) {
+  if (cashAmount <= 0 && creditAmount <= 0) {
+    throw new AppError(400, "bad_request", "ต้องระบุจำนวนเงินที่จะฝากอย่างน้อยหนึ่งอย่าง");
+  }
+
+  await getOrCreateWallet(tx, userId);
+
+  if (cashAmount > 0) {
+    await tx
+      .update(walletsTable)
+      .set({
+        balanceCash: sql`${walletsTable.balanceCash} + ${cashAmount}::numeric`,
+      })
+      .where(eq(walletsTable.userId, userId));
+
+    await tx.insert(transactionsTable).values({
+      userId,
+      type: "transfer",
+      currency: "cash",
+      amount: String(cashAmount),
+      note: note ?? "deposit",
+    });
+  }
+
+  if (creditAmount > 0) {
+    await tx
+      .update(walletsTable)
+      .set({
+        balanceCredit: sql`${walletsTable.balanceCredit} + ${creditAmount}::numeric`,
+      })
+      .where(eq(walletsTable.userId, userId));
+
+    await tx.insert(transactionsTable).values({
+      userId,
+      type: "transfer",
+      currency: "credit",
+      amount: String(creditAmount),
+      note: note ?? "deposit",
+    });
+  }
+
+  return getOrCreateWallet(tx, userId);
 }
 
 export async function lockFunds(
@@ -37,14 +131,14 @@ export async function lockFunds(
 ) {
   if (cashAmount === 0 && creditAmount === 0) return;
 
-  // FOR UPDATE prevents concurrent offers from spending the same balance
+  // FOR UPDATE prevents two concurrent offers spending the same balance
   const [wallet] = await tx
     .select()
     .from(walletsTable)
     .where(eq(walletsTable.userId, userId))
     .for("update");
 
-  if (!wallet) throw new AppError(400, "wallet_not_found", "กระเป๋าเงินไม่พบ");
+  if (!wallet) throw new AppError(400, "wallet_not_found", "ไม่พบกระเป๋าเงิน");
 
   if (cashAmount > 0 && Number(wallet.balanceCash) < cashAmount) {
     throw new AppError(409, "insufficient_funds", "ยอดเงินสดไม่เพียงพอ");
@@ -53,15 +147,14 @@ export async function lockFunds(
     throw new AppError(409, "insufficient_funds", "ยอดเครดิตไม่เพียงพอ");
   }
 
-  await tx
-    .update(walletsTable)
-    .set({
-      balanceCash: sql`${walletsTable.balanceCash} - ${cashAmount}::numeric`,
-      balanceCredit: sql`${walletsTable.balanceCredit} - ${creditAmount}::numeric`,
-    })
-    .where(eq(walletsTable.userId, userId));
-
   if (cashAmount > 0) {
+    await tx
+      .update(walletsTable)
+      .set({
+        balanceCash: sql`${walletsTable.balanceCash} - ${cashAmount}::numeric`,
+      })
+      .where(eq(walletsTable.userId, userId));
+
     await tx.insert(transactionsTable).values({
       userId,
       type: "lock",
@@ -70,7 +163,15 @@ export async function lockFunds(
       offerId,
     });
   }
+
   if (creditAmount > 0) {
+    await tx
+      .update(walletsTable)
+      .set({
+        balanceCredit: sql`${walletsTable.balanceCredit} - ${creditAmount}::numeric`,
+      })
+      .where(eq(walletsTable.userId, userId));
+
     await tx.insert(transactionsTable).values({
       userId,
       type: "lock",
@@ -97,15 +198,22 @@ export async function releaseFunds(
     );
 
   for (const lock of locks) {
-    const column =
-      lock.currency === "cash"
-        ? walletsTable.balanceCash
-        : walletsTable.balanceCredit;
-
-    await tx
-      .update(walletsTable)
-      .set({ [column.name]: sql`${column} + ${lock.amount}::numeric` })
-      .where(eq(walletsTable.userId, userId));
+    // Explicit branches — Drizzle .set() requires TS property names, not SQL column names
+    if (lock.currency === "cash") {
+      await tx
+        .update(walletsTable)
+        .set({
+          balanceCash: sql`${walletsTable.balanceCash} + ${lock.amount}::numeric`,
+        })
+        .where(eq(walletsTable.userId, userId));
+    } else {
+      await tx
+        .update(walletsTable)
+        .set({
+          balanceCredit: sql`${walletsTable.balanceCredit} + ${lock.amount}::numeric`,
+        })
+        .where(eq(walletsTable.userId, userId));
+    }
 
     await tx.insert(transactionsTable).values({
       userId,
@@ -125,7 +233,6 @@ export async function transferFunds(
     offerId,
   }: { fromUserId: string; toUserId: string; offerId: string },
 ) {
-  // Ensure recipient has a wallet
   await getOrCreateWallet(tx, toUserId);
 
   const locks = await tx
@@ -140,15 +247,22 @@ export async function transferFunds(
     );
 
   for (const lock of locks) {
-    const column =
-      lock.currency === "cash"
-        ? walletsTable.balanceCash
-        : walletsTable.balanceCredit;
-
-    await tx
-      .update(walletsTable)
-      .set({ [column.name]: sql`${column} + ${lock.amount}::numeric` })
-      .where(eq(walletsTable.userId, toUserId));
+    // Explicit branches — same reason as releaseFunds
+    if (lock.currency === "cash") {
+      await tx
+        .update(walletsTable)
+        .set({
+          balanceCash: sql`${walletsTable.balanceCash} + ${lock.amount}::numeric`,
+        })
+        .where(eq(walletsTable.userId, toUserId));
+    } else {
+      await tx
+        .update(walletsTable)
+        .set({
+          balanceCredit: sql`${walletsTable.balanceCredit} + ${lock.amount}::numeric`,
+        })
+        .where(eq(walletsTable.userId, toUserId));
+    }
 
     await tx.insert(transactionsTable).values({
       userId: fromUserId,

--- a/artifacts/api-server/src/services/wallet.service.ts
+++ b/artifacts/api-server/src/services/wallet.service.ts
@@ -1,0 +1,171 @@
+import { db, walletsTable, transactionsTable } from "@workspace/db";
+import { and, eq, sql } from "drizzle-orm";
+import { AppError } from "../lib/errors";
+
+type DbOrTx =
+  | typeof db
+  | Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+export async function getOrCreateWallet(tx: DbOrTx, userId: string) {
+  const [existing] = await tx
+    .select()
+    .from(walletsTable)
+    .where(eq(walletsTable.userId, userId));
+
+  if (existing) return existing;
+
+  const [created] = await tx
+    .insert(walletsTable)
+    .values({ userId })
+    .returning();
+  return created;
+}
+
+export async function lockFunds(
+  tx: DbOrTx,
+  {
+    userId,
+    offerId,
+    cashAmount,
+    creditAmount,
+  }: {
+    userId: string;
+    offerId: string;
+    cashAmount: number;
+    creditAmount: number;
+  },
+) {
+  if (cashAmount === 0 && creditAmount === 0) return;
+
+  // FOR UPDATE prevents concurrent offers from spending the same balance
+  const [wallet] = await tx
+    .select()
+    .from(walletsTable)
+    .where(eq(walletsTable.userId, userId))
+    .for("update");
+
+  if (!wallet) throw new AppError(400, "wallet_not_found", "กระเป๋าเงินไม่พบ");
+
+  if (cashAmount > 0 && Number(wallet.balanceCash) < cashAmount) {
+    throw new AppError(409, "insufficient_funds", "ยอดเงินสดไม่เพียงพอ");
+  }
+  if (creditAmount > 0 && Number(wallet.balanceCredit) < creditAmount) {
+    throw new AppError(409, "insufficient_funds", "ยอดเครดิตไม่เพียงพอ");
+  }
+
+  await tx
+    .update(walletsTable)
+    .set({
+      balanceCash: sql`${walletsTable.balanceCash} - ${cashAmount}::numeric`,
+      balanceCredit: sql`${walletsTable.balanceCredit} - ${creditAmount}::numeric`,
+    })
+    .where(eq(walletsTable.userId, userId));
+
+  if (cashAmount > 0) {
+    await tx.insert(transactionsTable).values({
+      userId,
+      type: "lock",
+      currency: "cash",
+      amount: String(cashAmount),
+      offerId,
+    });
+  }
+  if (creditAmount > 0) {
+    await tx.insert(transactionsTable).values({
+      userId,
+      type: "lock",
+      currency: "credit",
+      amount: String(creditAmount),
+      offerId,
+    });
+  }
+}
+
+export async function releaseFunds(
+  tx: DbOrTx,
+  { userId, offerId }: { userId: string; offerId: string },
+) {
+  const locks = await tx
+    .select()
+    .from(transactionsTable)
+    .where(
+      and(
+        eq(transactionsTable.userId, userId),
+        eq(transactionsTable.offerId, offerId),
+        eq(transactionsTable.type, "lock"),
+      ),
+    );
+
+  for (const lock of locks) {
+    const column =
+      lock.currency === "cash"
+        ? walletsTable.balanceCash
+        : walletsTable.balanceCredit;
+
+    await tx
+      .update(walletsTable)
+      .set({ [column.name]: sql`${column} + ${lock.amount}::numeric` })
+      .where(eq(walletsTable.userId, userId));
+
+    await tx.insert(transactionsTable).values({
+      userId,
+      type: "refund",
+      currency: lock.currency,
+      amount: lock.amount,
+      offerId,
+    });
+  }
+}
+
+export async function transferFunds(
+  tx: DbOrTx,
+  {
+    fromUserId,
+    toUserId,
+    offerId,
+  }: { fromUserId: string; toUserId: string; offerId: string },
+) {
+  // Ensure recipient has a wallet
+  await getOrCreateWallet(tx, toUserId);
+
+  const locks = await tx
+    .select()
+    .from(transactionsTable)
+    .where(
+      and(
+        eq(transactionsTable.userId, fromUserId),
+        eq(transactionsTable.offerId, offerId),
+        eq(transactionsTable.type, "lock"),
+      ),
+    );
+
+  for (const lock of locks) {
+    const column =
+      lock.currency === "cash"
+        ? walletsTable.balanceCash
+        : walletsTable.balanceCredit;
+
+    await tx
+      .update(walletsTable)
+      .set({ [column.name]: sql`${column} + ${lock.amount}::numeric` })
+      .where(eq(walletsTable.userId, toUserId));
+
+    await tx.insert(transactionsTable).values({
+      userId: fromUserId,
+      type: "transfer",
+      currency: lock.currency,
+      amount: lock.amount,
+      offerId,
+      note: `transfer_to:${toUserId}`,
+    });
+
+    await tx.insert(transactionsTable).values({
+      userId: toUserId,
+      type: "transfer",
+      currency: lock.currency,
+      amount: lock.amount,
+      offerId,
+      note: `received_from:${fromUserId}`,
+    });
+  }
+}

--- a/lib/db/src/schema/index.ts
+++ b/lib/db/src/schema/index.ts
@@ -8,3 +8,5 @@ export * from "./conversations";
 export * from "./messages";
 export * from "./notifications";
 export * from "./bookmarks";
+export * from "./wallet";
+export * from "./offer_chats";

--- a/lib/db/src/schema/items.ts
+++ b/lib/db/src/schema/items.ts
@@ -15,6 +15,8 @@ export const dealTypeEnum = pgEnum("deal_type", ["swap", "buy", "both"]);
 export const itemStatusEnum = pgEnum("item_status", [
   "active",
   "paused",
+  "locked",
+  "traded",
   "closed",
 ]);
 

--- a/lib/db/src/schema/notifications.ts
+++ b/lib/db/src/schema/notifications.ts
@@ -18,6 +18,8 @@ export const notificationTypeEnum = pgEnum("notification_type", [
   "offer_received",
   "offer_accepted",
   "offer_rejected",
+  "offer_cancelled",
+  "offer_confirmed",
   "deal_stage_updated",
 ]);
 

--- a/lib/db/src/schema/offer_chats.ts
+++ b/lib/db/src/schema/offer_chats.ts
@@ -1,0 +1,52 @@
+import { sql } from "drizzle-orm";
+import {
+  index,
+  pgTable,
+  text,
+  timestamp,
+  varchar,
+} from "drizzle-orm/pg-core";
+import { offersTable } from "./offers";
+import { usersTable } from "./auth";
+
+// One chat room per offer, created automatically on offer creation
+export const offerChatsTable = pgTable("offer_chats", {
+  id: varchar("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  offerId: varchar("offer_id")
+    .notNull()
+    .unique()
+    .references(() => offersTable.id, { onDelete: "cascade" }),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+export const offerMessagesTable = pgTable(
+  "offer_messages",
+  {
+    id: varchar("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    chatId: varchar("chat_id")
+      .notNull()
+      .references(() => offerChatsTable.id, { onDelete: "cascade" }),
+    senderId: varchar("sender_id")
+      .notNull()
+      .references(() => usersTable.id, { onDelete: "cascade" }),
+    message: text("message").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("offer_messages_chat_created_idx").on(
+      table.chatId,
+      table.createdAt,
+    ),
+  ],
+);
+
+export type OfferChat = typeof offerChatsTable.$inferSelect;
+export type OfferMessage = typeof offerMessagesTable.$inferSelect;

--- a/lib/db/src/schema/offers.ts
+++ b/lib/db/src/schema/offers.ts
@@ -1,10 +1,12 @@
 import { sql } from "drizzle-orm";
 import {
-  integer,
+  index,
+  numeric,
   pgEnum,
   pgTable,
   text,
   timestamp,
+  uniqueIndex,
   varchar,
 } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
@@ -17,6 +19,8 @@ export const offerStatusEnum = pgEnum("offer_status", [
   "accepted",
   "rejected",
   "canceled",
+  "shipping",
+  "completed",
 ]);
 
 export const offersTable = pgTable("offers", {
@@ -33,18 +37,82 @@ export const offersTable = pgTable("offers", {
     .notNull()
     .references(() => usersTable.id, { onDelete: "cascade" }),
   status: offerStatusEnum("status").notNull().default("pending"),
-  offeredCash: integer("offered_cash").notNull().default(0),
-  offeredCredit: integer("offered_credit").notNull().default(0),
+  // denormalised totals kept for backward-compat with deals route
+  offeredCash: numeric("offered_cash", { precision: 14, scale: 2 })
+    .notNull()
+    .default("0"),
+  offeredCredit: numeric("offered_credit", { precision: 14, scale: 2 })
+    .notNull()
+    .default("0"),
   message: text("message"),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
 });
+
+// Individual components of an offer: each row is one product OR one money chunk
+export const offerItemsTable = pgTable(
+  "offer_items",
+  {
+    id: varchar("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    offerId: varchar("offer_id")
+      .notNull()
+      .references(() => offersTable.id, { onDelete: "cascade" }),
+    productId: varchar("product_id").references(() => itemsTable.id, {
+      onDelete: "set null",
+    }),
+    cashAmount: numeric("cash_amount", { precision: 14, scale: 2 })
+      .notNull()
+      .default("0"),
+    creditAmount: numeric("credit_amount", { precision: 14, scale: 2 })
+      .notNull()
+      .default("0"),
+  },
+  (table) => [index("offer_items_offer_id_idx").on(table.offerId)],
+);
+
+// One row per user who confirmed — UNIQUE prevents double-confirm at DB level
+export const offerConfirmationsTable = pgTable(
+  "offer_confirmations",
+  {
+    id: varchar("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    offerId: varchar("offer_id")
+      .notNull()
+      .references(() => offersTable.id, { onDelete: "cascade" }),
+    userId: varchar("user_id")
+      .notNull()
+      .references(() => usersTable.id, { onDelete: "cascade" }),
+    confirmedAt: timestamp("confirmed_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("offer_confirmations_offer_user_unique").on(
+      table.offerId,
+      table.userId,
+    ),
+  ],
+);
 
 export const insertOfferSchema = createInsertSchema(offersTable).omit({
   id: true,
   createdAt: true,
+  updatedAt: true,
   status: true,
 });
+export const insertOfferItemSchema = createInsertSchema(offerItemsTable).omit({
+  id: true,
+});
+
 export type InsertOffer = z.infer<typeof insertOfferSchema>;
 export type Offer = typeof offersTable.$inferSelect;
+export type OfferItem = typeof offerItemsTable.$inferSelect;
+export type OfferConfirmation = typeof offerConfirmationsTable.$inferSelect;

--- a/lib/db/src/schema/wallet.ts
+++ b/lib/db/src/schema/wallet.ts
@@ -1,0 +1,76 @@
+import { sql } from "drizzle-orm";
+import {
+  index,
+  numeric,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  varchar,
+} from "drizzle-orm/pg-core";
+import { createInsertSchema } from "drizzle-zod";
+import { z } from "zod/v4";
+import { usersTable } from "./auth";
+import { offersTable } from "./offers";
+
+export const transactionTypeEnum = pgEnum("transaction_type", [
+  "lock",
+  "transfer",
+  "refund",
+]);
+
+export const currencyTypeEnum = pgEnum("currency_type", ["cash", "credit"]);
+
+export const walletsTable = pgTable("wallets", {
+  id: varchar("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  userId: varchar("user_id")
+    .notNull()
+    .unique()
+    .references(() => usersTable.id, { onDelete: "cascade" }),
+  balanceCash: numeric("balance_cash", { precision: 14, scale: 2 })
+    .notNull()
+    .default("0"),
+  balanceCredit: numeric("balance_credit", { precision: 14, scale: 2 })
+    .notNull()
+    .default("0"),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
+});
+
+export const transactionsTable = pgTable(
+  "transactions",
+  {
+    id: varchar("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    userId: varchar("user_id")
+      .notNull()
+      .references(() => usersTable.id, { onDelete: "cascade" }),
+    type: transactionTypeEnum("type").notNull(),
+    currency: currencyTypeEnum("currency").notNull(),
+    amount: numeric("amount", { precision: 14, scale: 2 }).notNull(),
+    offerId: varchar("offer_id").references(() => offersTable.id, {
+      onDelete: "set null",
+    }),
+    note: text("note"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("transactions_user_id_idx").on(table.userId),
+    index("transactions_offer_id_idx").on(table.offerId),
+  ],
+);
+
+export const insertTransactionSchema = createInsertSchema(
+  transactionsTable,
+).omit({ id: true, createdAt: true });
+
+export type Wallet = typeof walletsTable.$inferSelect;
+export type Transaction = typeof transactionsTable.$inferSelect;
+export type InsertTransaction = z.infer<typeof insertTransactionSchema>;


### PR DESCRIPTION
## Summary

- **Connect bookmarks to Drizzle schema** — remove inline `CREATE TABLE` hack, populate `qxwap_supabase_schema_policy.sql` with full schema
- **Offers module** — full lifecycle state machine (create → accept/reject/cancel → confirm → complete) with service layer, `offer_items`, `offer_confirmations`, auto-create chat per offer
- **Wallet & transaction system** — `lockFunds` / `releaseFunds` / `transferFunds` with `SELECT FOR UPDATE`, prevent negative balance, `GET /wallet`, `GET /transactions`, `POST /wallet/deposit`
- **Product locking system** — `product.service.ts` with `validateProductsAvailable`, `lockProducts`, `unlockProducts`, `tradeProducts`; target item locked on accept, unlocked conditionally on cancel/reject

## New files
- `lib/db/src/schema/wallet.ts` — wallets + transactions tables
- `lib/db/src/schema/offer_chats.ts` — offer chat rooms + messages
- `artifacts/api-server/src/lib/errors.ts` — `AppError` class
- `artifacts/api-server/src/services/offer.service.ts`
- `artifacts/api-server/src/services/wallet.service.ts`
- `artifacts/api-server/src/services/notification.service.ts`
- `artifacts/api-server/src/services/product.service.ts`
- `artifacts/api-server/src/routes/wallet.ts`

---
_Generated by [Claude Code](https://claude.ai/code/session_017yzXFgBwq2omG3Dq1nhNCv)_