### PR TITLE
Implement offer confirmation, shipping, and chat systems

### DIFF
--- a/artifacts/api-server/src/routes/index.ts
+++ b/artifacts/api-server/src/routes/index.ts
@@ -10,6 +10,8 @@ import bookmarksRouter from "./bookmarks";
 import dealsRouter from "./deals";
 import notificationsRouter from "./notifications";
 import walletRouter from "./wallet";
+import shipmentsRouter from "./shipments";
+import offerChatsRouter from "./offer_chats";
 
 const router: IRouter = Router();
 
@@ -24,5 +26,7 @@ router.use(dealsRouter);
 router.use(chatRouter);
 router.use(notificationsRouter);
 router.use(walletRouter);
+router.use(shipmentsRouter);
+router.use(offerChatsRouter);
 
 export default router;

--- a/artifacts/api-server/src/routes/offer_chats.ts
+++ b/artifacts/api-server/src/routes/offer_chats.ts
@@ -1,0 +1,70 @@
+import { Router, type IRouter, type Request, type Response } from "express";
+import { z } from "zod/v4";
+import { requireAuth } from "../middlewares/authMiddleware";
+import { sendError, sendValidationError } from "../lib/http";
+import { AppError } from "../lib/errors";
+import * as OfferChatService from "../services/offer_chat.service";
+
+const router: IRouter = Router();
+
+function handleError(res: Response, err: unknown) {
+  if (err instanceof AppError) {
+    sendError(res, err.statusCode, err.code, err.message);
+    return;
+  }
+  throw err;
+}
+
+// ─── GET /chats/:offer_id ─────────────────────────────────────
+
+router.get(
+  "/chats/:offer_id",
+  requireAuth,
+  async (req: Request, res: Response) => {
+    if (!req.isAuthenticated()) return;
+    const offerId = String(req.params.offer_id);
+    try {
+      const result = await OfferChatService.getChatByOfferId(
+        offerId,
+        req.user.id,
+      );
+      res.json(result);
+    } catch (err) {
+      handleError(res, err);
+    }
+  },
+);
+
+// ─── POST /messages ───────────────────────────────────────────
+
+const sendMessageSchema = z.object({
+  offerId: z.string().min(1),
+  message: z.string().trim().min(1).max(4000),
+});
+
+router.post(
+  "/messages",
+  requireAuth,
+  async (req: Request, res: Response) => {
+    if (!req.isAuthenticated()) return;
+
+    const parsed = sendMessageSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendValidationError(res, "ข้อมูลข้อความไม่ถูกต้อง", parsed.error);
+      return;
+    }
+
+    try {
+      const message = await OfferChatService.sendMessage(
+        parsed.data.offerId,
+        req.user.id,
+        parsed.data.message,
+      );
+      res.status(201).json({ message });
+    } catch (err) {
+      handleError(res, err);
+    }
+  },
+);
+
+export default router;

--- a/artifacts/api-server/src/routes/shipments.ts
+++ b/artifacts/api-server/src/routes/shipments.ts
@@ -1,0 +1,109 @@
+import { Router, type IRouter, type Request, type Response } from "express";
+import { z } from "zod/v4";
+import { requireAuth } from "../middlewares/authMiddleware";
+import { sendError, sendValidationError } from "../lib/http";
+import { AppError } from "../lib/errors";
+import * as ShipmentService from "../services/shipment.service";
+
+const router: IRouter = Router();
+
+function handleError(res: Response, err: unknown) {
+  if (err instanceof AppError) {
+    sendError(res, err.statusCode, err.code, err.message);
+    return;
+  }
+  throw err;
+}
+
+// ─── POST /shipments/:offer_id/start ─────────────────────────
+// Idempotent: creates shipment if not yet created (offer must be in "shipping" status)
+
+router.post(
+  "/shipments/:offer_id/start",
+  requireAuth,
+  async (req: Request, res: Response) => {
+    if (!req.isAuthenticated()) return;
+    const offerId = String(req.params.offer_id);
+    try {
+      const shipment = await ShipmentService.ensureShipment(offerId);
+      res.status(201).json({ shipment });
+    } catch (err) {
+      handleError(res, err);
+    }
+  },
+);
+
+// ─── POST /shipments/:id/update-step ─────────────────────────
+// Valid stepName values: packed | shipped | delivered
+
+const updateStepSchema = z.object({
+  stepName: z.string().min(1),
+  note: z.string().max(500).optional(),
+});
+
+router.post(
+  "/shipments/:id/update-step",
+  requireAuth,
+  async (req: Request, res: Response) => {
+    if (!req.isAuthenticated()) return;
+    const shipmentId = String(req.params.id);
+
+    const parsed = updateStepSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendValidationError(res, "ข้อมูลขั้นตอนไม่ถูกต้อง", parsed.error);
+      return;
+    }
+
+    try {
+      const result = await ShipmentService.addStep(
+        shipmentId,
+        parsed.data.stepName,
+        parsed.data.note,
+      );
+      res.json(result);
+    } catch (err) {
+      handleError(res, err);
+    }
+  },
+);
+
+// ─── POST /shipments/:id/finish ──────────────────────────────
+// Marks shipment finished → transfers products + funds → offer → completed
+
+router.post(
+  "/shipments/:id/finish",
+  requireAuth,
+  async (req: Request, res: Response) => {
+    if (!req.isAuthenticated()) return;
+    const shipmentId = String(req.params.id);
+
+    try {
+      const result = await ShipmentService.finishShipment(shipmentId);
+      res.json(result);
+    } catch (err) {
+      handleError(res, err);
+    }
+  },
+);
+
+// ─── GET /shipments/:offer_id ────────────────────────────────
+
+router.get(
+  "/shipments/:offer_id",
+  requireAuth,
+  async (req: Request, res: Response) => {
+    if (!req.isAuthenticated()) return;
+    const offerId = String(req.params.offer_id);
+
+    const shipment = await ShipmentService.getByOfferId(offerId);
+    if (!shipment) {
+      sendError(res, 404, "not_found", "ไม่พบข้อมูลการจัดส่ง");
+      return;
+    }
+
+    const steps = await ShipmentService.getSteps(shipment.id);
+    res.json({ shipment, steps });
+  },
+);
+
+export default router;

--- a/artifacts/api-server/src/services/offer.service.ts
+++ b/artifacts/api-server/src/services/offer.service.ts
@@ -5,6 +5,7 @@ import {
   offerConfirmationsTable,
   offerItemsTable,
   offersTable,
+  shipmentsTable,
 } from "@workspace/db";
 import { and, count, desc, eq, or } from "drizzle-orm";
 import { AppError } from "../lib/errors";
@@ -347,9 +348,9 @@ export async function confirmOffer(offerId: string, userId: string) {
       title: "อีกฝ่ายยืนยันแล้ว",
     });
 
-    // Both sides confirmed → complete transaction
+    // Both sides confirmed → move to shipping, create shipment record
     if (total >= 2) {
-      return completeTrade(tx, offer);
+      return startShipment(tx, offer);
     }
 
     return { offer, bothConfirmed: false };
@@ -416,7 +417,41 @@ async function unlockOfferAssets(tx: DbOrTx, offer: OfferRow) {
   });
 }
 
-async function completeTrade(tx: DbOrTx, offer: OfferRow) {
+async function startShipment(tx: DbOrTx, offer: OfferRow) {
+  // Set offer to "shipping"
+  const [updated] = await tx
+    .update(offersTable)
+    .set({ status: "shipping" })
+    .where(eq(offersTable.id, offer.id))
+    .returning();
+
+  // Create shipment record (UNIQUE on offer_id prevents duplicates)
+  const [shipment] = await tx
+    .insert(shipmentsTable)
+    .values({ offerId: offer.id, status: "pending" })
+    .onConflictDoNothing()
+    .returning();
+
+  await NotificationService.notify(tx, {
+    userId: offer.senderId,
+    actorId: offer.receiverId,
+    type: "offer_confirmed",
+    offerId: offer.id,
+    title: "ทั้งสองฝ่ายยืนยันแล้ว กำลังดำเนินการจัดส่ง",
+  });
+  await NotificationService.notify(tx, {
+    userId: offer.receiverId,
+    actorId: offer.senderId,
+    type: "offer_confirmed",
+    offerId: offer.id,
+    title: "ทั้งสองฝ่ายยืนยันแล้ว กำลังดำเนินการจัดส่ง",
+  });
+
+  return { offer: updated, shipment, bothConfirmed: true };
+}
+
+// Exported so shipment.service can call it when shipment finishes
+export async function completeTrade(tx: DbOrTx, offer: OfferRow) {
   // 1. Transfer sender's offered products → receiver
   const offerItems = await tx
     .select({ productId: offerItemsTable.productId })

--- a/artifacts/api-server/src/services/offer_chat.service.ts
+++ b/artifacts/api-server/src/services/offer_chat.service.ts
@@ -1,0 +1,78 @@
+import { db, offerChatsTable, offerMessagesTable, offersTable } from "@workspace/db";
+import { asc, eq } from "drizzle-orm";
+import { AppError } from "../lib/errors";
+
+// ─── Queries ─────────────────────────────────────────────────
+
+export async function getChatByOfferId(offerId: string, requesterId: string) {
+  // Verify requester is a participant
+  const [offer] = await db
+    .select({
+      senderId: offersTable.senderId,
+      receiverId: offersTable.receiverId,
+    })
+    .from(offersTable)
+    .where(eq(offersTable.id, offerId));
+
+  if (!offer) throw new AppError(404, "not_found", "ไม่พบข้อเสนอ");
+  if (offer.senderId !== requesterId && offer.receiverId !== requesterId) {
+    throw new AppError(403, "forbidden", "ไม่มีสิทธิ์เข้าถึงแชทนี้");
+  }
+
+  const [chat] = await db
+    .select()
+    .from(offerChatsTable)
+    .where(eq(offerChatsTable.offerId, offerId));
+
+  if (!chat) throw new AppError(404, "not_found", "ไม่พบแชทสำหรับข้อเสนอนี้");
+
+  const messages = await db
+    .select()
+    .from(offerMessagesTable)
+    .where(eq(offerMessagesTable.chatId, chat.id))
+    .orderBy(asc(offerMessagesTable.createdAt));
+
+  return { chat, messages };
+}
+
+// ─── Send message ─────────────────────────────────────────────
+
+export async function sendMessage(
+  offerId: string,
+  senderId: string,
+  message: string,
+) {
+  return db.transaction(async (tx) => {
+    // Verify sender is a participant
+    const [offer] = await tx
+      .select({
+        senderId: offersTable.senderId,
+        receiverId: offersTable.receiverId,
+        status: offersTable.status,
+      })
+      .from(offersTable)
+      .where(eq(offersTable.id, offerId));
+
+    if (!offer) throw new AppError(404, "not_found", "ไม่พบข้อเสนอ");
+    if (offer.senderId !== senderId && offer.receiverId !== senderId) {
+      throw new AppError(403, "forbidden", "ไม่มีสิทธิ์ส่งข้อความในแชทนี้");
+    }
+    if (offer.status === "completed" || offer.status === "rejected" || offer.status === "canceled") {
+      throw new AppError(409, "invalid_state", "ไม่สามารถส่งข้อความในข้อเสนอที่สิ้นสุดแล้ว");
+    }
+
+    const [chat] = await tx
+      .select()
+      .from(offerChatsTable)
+      .where(eq(offerChatsTable.offerId, offerId));
+
+    if (!chat) throw new AppError(404, "not_found", "ไม่พบแชทสำหรับข้อเสนอนี้");
+
+    const [created] = await tx
+      .insert(offerMessagesTable)
+      .values({ chatId: chat.id, senderId, message })
+      .returning();
+
+    return created;
+  });
+}

--- a/artifacts/api-server/src/services/shipment.service.ts
+++ b/artifacts/api-server/src/services/shipment.service.ts
@@ -1,0 +1,165 @@
+import {
+  db,
+  offersTable,
+  shipmentsTable,
+  shipmentStepsTable,
+} from "@workspace/db";
+import { eq } from "drizzle-orm";
+import { AppError } from "../lib/errors";
+import { completeTrade } from "./offer.service";
+
+type DbOrTx =
+  | typeof db
+  | Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+const VALID_STEPS = ["packed", "shipped", "delivered"] as const;
+type StepName = (typeof VALID_STEPS)[number];
+
+// Step name → shipment status mapping
+const STEP_TO_STATUS: Record<StepName, typeof shipmentsTable.$inferSelect["status"]> = {
+  packed: "pending",
+  shipped: "shipped",
+  delivered: "delivered",
+};
+
+// ─── Queries ─────────────────────────────────────────────────
+
+export async function getByOfferId(offerId: string) {
+  const [shipment] = await db
+    .select()
+    .from(shipmentsTable)
+    .where(eq(shipmentsTable.offerId, offerId));
+  return shipment ?? null;
+}
+
+export async function getById(shipmentId: string) {
+  const [shipment] = await db
+    .select()
+    .from(shipmentsTable)
+    .where(eq(shipmentsTable.id, shipmentId));
+  return shipment ?? null;
+}
+
+export async function getSteps(shipmentId: string) {
+  return db
+    .select()
+    .from(shipmentStepsTable)
+    .where(eq(shipmentStepsTable.shipmentId, shipmentId));
+}
+
+// ─── Create ───────────────────────────────────────────────────
+
+export async function ensureShipment(offerId: string) {
+  return db.transaction(async (tx) => {
+    const [offer] = await tx
+      .select()
+      .from(offersTable)
+      .where(eq(offersTable.id, offerId))
+      .for("update");
+
+    if (!offer) throw new AppError(404, "not_found", "ไม่พบข้อเสนอ");
+    if (offer.status !== "shipping") {
+      throw new AppError(
+        409,
+        "invalid_state",
+        "สามารถเริ่มการจัดส่งได้เฉพาะข้อเสนอที่ทั้งสองฝ่ายยืนยันแล้ว",
+      );
+    }
+
+    // Idempotent: return existing if already created
+    const existing = await getByOfferId(offerId);
+    if (existing) return existing;
+
+    const [shipment] = await tx
+      .insert(shipmentsTable)
+      .values({ offerId, status: "pending" })
+      .returning();
+
+    return shipment;
+  });
+}
+
+// ─── Add step ────────────────────────────────────────────────
+
+export async function addStep(
+  shipmentId: string,
+  stepName: string,
+  note?: string,
+) {
+  if (!VALID_STEPS.includes(stepName as StepName)) {
+    throw new AppError(
+      400,
+      "invalid_step",
+      `ขั้นตอนต้องเป็น: ${VALID_STEPS.join(", ")}`,
+    );
+  }
+
+  return db.transaction(async (tx) => {
+    const [shipment] = await tx
+      .select()
+      .from(shipmentsTable)
+      .where(eq(shipmentsTable.id, shipmentId))
+      .for("update");
+
+    if (!shipment) throw new AppError(404, "not_found", "ไม่พบข้อมูลการจัดส่ง");
+    if (shipment.status === "finished") {
+      throw new AppError(409, "invalid_state", "การจัดส่งเสร็จสิ้นแล้ว");
+    }
+
+    const [step] = await tx
+      .insert(shipmentStepsTable)
+      .values({ shipmentId, stepName, note: note ?? null })
+      .returning();
+
+    // Advance shipment status if step maps to a higher state
+    const nextStatus = STEP_TO_STATUS[stepName as StepName];
+    await tx
+      .update(shipmentsTable)
+      .set({ status: nextStatus })
+      .where(eq(shipmentsTable.id, shipmentId));
+
+    return { ...shipment, status: nextStatus, step };
+  });
+}
+
+// ─── Finish ──────────────────────────────────────────────────
+
+export async function finishShipment(shipmentId: string) {
+  return db.transaction(async (tx) => {
+    const [shipment] = await tx
+      .select()
+      .from(shipmentsTable)
+      .where(eq(shipmentsTable.id, shipmentId))
+      .for("update");
+
+    if (!shipment) throw new AppError(404, "not_found", "ไม่พบข้อมูลการจัดส่ง");
+    if (shipment.status === "finished") {
+      throw new AppError(409, "invalid_state", "การจัดส่งเสร็จสิ้นแล้วแล้ว");
+    }
+
+    // Add finished step
+    await tx
+      .insert(shipmentStepsTable)
+      .values({ shipmentId, stepName: "finished" });
+
+    // Mark shipment done
+    const [updatedShipment] = await tx
+      .update(shipmentsTable)
+      .set({ status: "finished" })
+      .where(eq(shipmentsTable.id, shipmentId))
+      .returning();
+
+    // Retrieve offer and complete the trade (transfer products + funds)
+    const [offer] = await tx
+      .select()
+      .from(offersTable)
+      .where(eq(offersTable.id, shipment.offerId))
+      .for("update");
+
+    if (!offer) throw new AppError(404, "not_found", "ไม่พบข้อเสนอที่เชื่อมกับการจัดส่งนี้");
+
+    const tradeResult = await completeTrade(tx, offer);
+
+    return { shipment: updatedShipment, offer: tradeResult.offer };
+  });
+}

--- a/lib/db/src/schema/index.ts
+++ b/lib/db/src/schema/index.ts
@@ -10,3 +10,4 @@ export * from "./notifications";
 export * from "./bookmarks";
 export * from "./wallet";
 export * from "./offer_chats";
+export * from "./shipments";

--- a/lib/db/src/schema/shipments.ts
+++ b/lib/db/src/schema/shipments.ts
@@ -1,0 +1,69 @@
+import { sql } from "drizzle-orm";
+import {
+  index,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  varchar,
+} from "drizzle-orm/pg-core";
+import { createInsertSchema } from "drizzle-zod";
+import { z } from "zod/v4";
+import { offersTable } from "./offers";
+
+export const shipmentStatusEnum = pgEnum("shipment_status", [
+  "pending",
+  "shipped",
+  "in_transit",
+  "delivered",
+  "finished",
+]);
+
+export const shipmentsTable = pgTable("shipments", {
+  id: varchar("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  offerId: varchar("offer_id")
+    .notNull()
+    .unique()
+    .references(() => offersTable.id, { onDelete: "restrict" }),
+  status: shipmentStatusEnum("status").notNull().default("pending"),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
+});
+
+export const shipmentStepsTable = pgTable(
+  "shipment_steps",
+  {
+    id: varchar("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    shipmentId: varchar("shipment_id")
+      .notNull()
+      .references(() => shipmentsTable.id, { onDelete: "cascade" }),
+    stepName: varchar("step_name", { length: 120 }).notNull(),
+    note: text("note"),
+    completedAt: timestamp("completed_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [index("shipment_steps_shipment_id_idx").on(table.shipmentId)],
+);
+
+export const insertShipmentSchema = createInsertSchema(shipmentsTable).omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+export const insertShipmentStepSchema = createInsertSchema(
+  shipmentStepsTable,
+).omit({ id: true });
+
+export type Shipment = typeof shipmentsTable.$inferSelect;
+export type ShipmentStep = typeof shipmentStepsTable.$inferSelect;
+export type InsertShipment = z.infer<typeof insertShipmentSchema>;


### PR DESCRIPTION
## Summary

- **Offer confirmation**: Both users must confirm before shipping begins. Stores confirmations in `offer_confirmations`, prevents duplicates, advances offer to `shipping` when both confirm.
- **Shipping system**: Full lifecycle — `POST /shipments/:offer_id/start` (idempotent), `POST /shipments/:id/update-step` (packed/shipped/delivered), `POST /shipments/:id/finish` (triggers `completeTrade`: transfers products + funds, marks offer `completed`).
- **Chat system**: One chat per offer (created at offer creation). `GET /chats/:offer_id` returns chat + messages ordered by time. `POST /messages` validates sender is a participant and offer is still active.

## New files
- `lib/db/src/schema/shipments.ts` — `shipments` + `shipment_steps` tables
- `lib/db/src/schema/offer_chats.ts` — `offer_chats` + `offer_messages` tables
- `artifacts/api-server/src/services/shipment.service.ts`
- `artifacts/api-server/src/services/offer_chat.service.ts`
- `artifacts/api-server/src/routes/shipments.ts`
- `artifacts/api-server/src/routes/offer_chats.ts`

## Modified files
- `offer.service.ts` — added `startShipment()`, exported `completeTrade`
- `routes/index.ts` — mounted shipments + offer_chats routers

---
_Generated by [Claude Code](https://claude.ai/code/session_017yzXFgBwq2omG3Dq1nhNCv)_