### PR TITLE
Implement notification system with shipping triggers

### DIFF
--- a/artifacts/api-server/src/routes/notifications.ts
+++ b/artifacts/api-server/src/routes/notifications.ts
@@ -1,12 +1,16 @@
 import { Router, type IRouter, type Request, type Response } from "express";
+import { z } from "zod/v4";
 import { db, notificationsTable } from "@workspace/db";
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 import { requireAuth } from "../middlewares/authMiddleware";
+import { sendError, sendValidationError } from "../lib/http";
 
 const router: IRouter = Router();
 
+// ─── GET /notifications ──────────────────────────────────────
+
 router.get(
-  "/notifications/mine",
+  "/notifications",
   requireAuth,
   async (req: Request, res: Response) => {
     if (!req.isAuthenticated()) return;
@@ -21,34 +25,44 @@ router.get(
   },
 );
 
-router.patch(
-  "/notifications/:id/read",
+// ─── POST /notifications/read ────────────────────────────────
+// Body: { ids?: string[] }
+// Omit ids to mark all as read.
+
+const markReadSchema = z.object({
+  ids: z.array(z.string().min(1)).optional(),
+});
+
+router.post(
+  "/notifications/read",
   requireAuth,
   async (req: Request, res: Response) => {
     if (!req.isAuthenticated()) return;
 
-    const [existing] = await db
-      .select()
-      .from(notificationsTable)
-      .where(eq(notificationsTable.id, String(req.params.id)));
-
-    if (!existing) {
-      res.status(404).json({ error: "ไม่พบการแจ้งเตือน" });
+    const parsed = markReadSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendValidationError(res, "ข้อมูลไม่ถูกต้อง", parsed.error);
       return;
     }
 
-    if (existing.userId !== req.user.id) {
-      res.status(403).json({ error: "ไม่อนุญาต" });
-      return;
-    }
+    const { ids } = parsed.data;
+    const userId = req.user.id;
 
-    const [updated] = await db
+    const filter =
+      ids && ids.length > 0
+        ? and(
+            eq(notificationsTable.userId, userId),
+            inArray(notificationsTable.id, ids),
+          )
+        : eq(notificationsTable.userId, userId);
+
+    const updated = await db
       .update(notificationsTable)
       .set({ isRead: true })
-      .where(eq(notificationsTable.id, existing.id))
+      .where(filter)
       .returning();
 
-    res.json({ notification: updated });
+    res.json({ updated: updated.length });
   },
 );
 

--- a/artifacts/api-server/src/services/offer.service.ts
+++ b/artifacts/api-server/src/services/offer.service.ts
@@ -485,14 +485,14 @@ export async function completeTrade(tx: DbOrTx, offer: OfferRow) {
   await NotificationService.notify(tx, {
     userId: offer.senderId,
     actorId: offer.receiverId,
-    type: "offer_confirmed",
+    type: "trade_completed",
     offerId: offer.id,
     title: "การแลกเปลี่ยนสำเร็จแล้ว",
   });
   await NotificationService.notify(tx, {
     userId: offer.receiverId,
     actorId: offer.senderId,
-    type: "offer_confirmed",
+    type: "trade_completed",
     offerId: offer.id,
     title: "การแลกเปลี่ยนสำเร็จแล้ว",
   });

--- a/artifacts/api-server/src/services/shipment.service.ts
+++ b/artifacts/api-server/src/services/shipment.service.ts
@@ -7,6 +7,7 @@ import {
 import { eq } from "drizzle-orm";
 import { AppError } from "../lib/errors";
 import { completeTrade } from "./offer.service";
+import * as NotificationService from "./notification.service";
 
 type DbOrTx =
   | typeof db
@@ -15,11 +16,16 @@ type DbOrTx =
 const VALID_STEPS = ["packed", "shipped", "delivered"] as const;
 type StepName = (typeof VALID_STEPS)[number];
 
-// Step name → shipment status mapping
 const STEP_TO_STATUS: Record<StepName, typeof shipmentsTable.$inferSelect["status"]> = {
   packed: "pending",
   shipped: "shipped",
   delivered: "delivered",
+};
+
+const STEP_LABEL: Record<StepName, string> = {
+  packed: "แพ็คสินค้าแล้ว",
+  shipped: "จัดส่งแล้ว",
+  delivered: "ได้รับสินค้าแล้ว",
 };
 
 // ─── Queries ─────────────────────────────────────────────────
@@ -111,12 +117,30 @@ export async function addStep(
       .values({ shipmentId, stepName, note: note ?? null })
       .returning();
 
-    // Advance shipment status if step maps to a higher state
     const nextStatus = STEP_TO_STATUS[stepName as StepName];
     await tx
       .update(shipmentsTable)
       .set({ status: nextStatus })
       .where(eq(shipmentsTable.id, shipmentId));
+
+    // Notify both offer participants about the shipping update
+    const [offer] = await tx
+      .select({ senderId: offersTable.senderId, receiverId: offersTable.receiverId })
+      .from(offersTable)
+      .where(eq(offersTable.id, shipment.offerId));
+
+    if (offer) {
+      const label = STEP_LABEL[stepName as StepName];
+      for (const userId of [offer.senderId, offer.receiverId]) {
+        await NotificationService.notify(tx, {
+          userId,
+          type: "shipment_updated",
+          offerId: shipment.offerId,
+          title: `สถานะการจัดส่งอัปเดต: ${label}`,
+          body: note,
+        });
+      }
+    }
 
     return { ...shipment, status: nextStatus, step };
   });
@@ -137,19 +161,16 @@ export async function finishShipment(shipmentId: string) {
       throw new AppError(409, "invalid_state", "การจัดส่งเสร็จสิ้นแล้วแล้ว");
     }
 
-    // Add finished step
     await tx
       .insert(shipmentStepsTable)
       .values({ shipmentId, stepName: "finished" });
 
-    // Mark shipment done
     const [updatedShipment] = await tx
       .update(shipmentsTable)
       .set({ status: "finished" })
       .where(eq(shipmentsTable.id, shipmentId))
       .returning();
 
-    // Retrieve offer and complete the trade (transfer products + funds)
     const [offer] = await tx
       .select()
       .from(offersTable)

--- a/lib/db/src/schema/notifications.ts
+++ b/lib/db/src/schema/notifications.ts
@@ -21,6 +21,8 @@ export const notificationTypeEnum = pgEnum("notification_type", [
   "offer_cancelled",
   "offer_confirmed",
   "deal_stage_updated",
+  "shipment_updated",
+  "trade_completed",
 ]);
 
 export const notificationsTable = pgTable(


### PR DESCRIPTION
## Summary

- **New notification types**: `shipment_updated` and `trade_completed` added to `notificationTypeEnum` in schema
- **Shipping notifications**: `addStep` now notifies both offer participants on every step (packed/shipped/delivered); `finishShipment` triggers `trade_completed` via `completeTrade`
- **Fixed**: `completeTrade` was incorrectly using `offer_confirmed` type — now correctly uses `trade_completed`
- **Routes rewritten**:
  - `GET /notifications` (renamed from `/notifications/mine`)
  - `POST /notifications/read` — batch mark-read; pass `{ ids: [...] }` for specific IDs, or omit `ids` to mark **all** as read

## Notification triggers
| Event | Type | Recipients |
|---|---|---|
| New offer | `offer_received` | receiver |
| Offer accepted | `offer_accepted` | sender |
| Offer rejected | `offer_rejected` | sender |
| Offer cancelled | `offer_cancelled` | other party |
| One side confirms | `offer_confirmed` | other party |
| Both confirmed → shipping | `offer_confirmed` | both |
| Shipping step update | `shipment_updated` | both |
| Trade completed | `trade_completed` | both |

---
_Generated by [Claude Code](https://claude.ai/code/session_017yzXFgBwq2omG3Dq1nhNCv)_