### PR TITLE
feat: Render deployment config + inject API_BASE from GitHub Secret

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -36,9 +36,17 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Prepare site
+        env:
+          API_BASE_URL: ${{ secrets.API_BASE_URL }}
         run: |
           mkdir -p _site
           cp artifacts/web-app/index.html _site/index.html
+          if [ -n "$API_BASE_URL" ]; then
+            sed -i "s|const API_BASE = '/api'|const API_BASE = '${API_BASE_URL}'|g" _site/index.html
+            echo "Injected API_BASE_URL: ${API_BASE_URL}"
+          else
+            echo "API_BASE_URL secret not set — using default /api"
+          fi
           [ -f artifacts/web-app/public/favicon.svg ] && cp artifacts/web-app/public/favicon.svg _site/favicon.svg || true
           [ -f artifacts/web-app/public/opengraph.jpg ] && cp artifacts/web-app/public/opengraph.jpg _site/opengraph.jpg || true
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,32 @@
+services:
+  - type: web
+    name: qxwap-api
+    env: node
+    region: singapore
+    plan: free
+    buildCommand: >
+      pnpm install &&
+      pnpm --filter @workspace/db exec tsc -p tsconfig.json &&
+      pnpm --filter @workspace/api-zod exec tsc -p tsconfig.json &&
+      node artifacts/api-server/build.mjs
+    startCommand: node artifacts/api-server/dist/index.mjs
+    healthCheckPath: /api/health
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: SESSION_SECRET
+        generateValue: true
+      - key: CORS_ORIGIN
+        value: https://aswer18400.github.io
+      - key: DATABASE_URL
+        sync: false
+      - key: SMTP_HOST
+        sync: false
+      - key: SMTP_PORT
+        sync: false
+      - key: SMTP_USER
+        sync: false
+      - key: SMTP_PASS
+        sync: false
+      - key: SMTP_FROM
+        sync: false


### PR DESCRIPTION
## Summary

- **`render.yaml`** — ไฟล์ config สำหรับ deploy Express API บน Render.com (free tier); build อัตโนมัติ, CORS ตั้ง `https://aswer18400.github.io` ล่วงหน้า
- **`deploy-pages.yml`** — ถ้า GitHub Secret `API_BASE_URL` ถูก set จะ inject URL นั้นเข้าไปใน `_site/index.html` แทน `/api` ก่อน deploy Pages

https://claude.ai/code/session_01WiC7GF1y7EcNzFWkfHDxW4

---
_Generated by [Claude Code](https://claude.ai/code/session_01WiC7GF1y7EcNzFWkfHDxW4)_