### PR TITLE
fix: push DB schema before server start on Render

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -9,6 +9,7 @@ services:
       pnpm --filter @workspace/db exec tsc -p tsconfig.json &&
       pnpm --filter @workspace/api-zod exec tsc -p tsconfig.json &&
       node artifacts/api-server/build.mjs
+    preDeployCommand: pnpm --filter @workspace/db run push
     startCommand: node artifacts/api-server/dist/index.mjs
     healthCheckPath: /api/healthz
     envVars:


### PR DESCRIPTION
เพิ่ม `preDeployCommand: pnpm --filter @workspace/db run push` ใน render.yaml — ทำให้ drizzle-kit สร้าง/sync tables ทุกครั้งก่อน server start แก้ error `relation "users" does not exist`

https://claude.ai/code/session_01WiC7GF1y7EcNzFWkfHDxW4

---
_Generated by [Claude Code](https://claude.ai/code/session_01WiC7GF1y7EcNzFWkfHDxW4)_