### PR TITLE
fix: replace all hardcoded /api/ fetch calls with API_BASE (#57)

### DIFF
--- a/artifacts/web-app/index.html
+++ b/artifacts/web-app/index.html
@@ -3406,8 +3406,8 @@ h1,h2,h3{font-weight:900;}
       go('credit');
       try {
         const [walletR, txR] = await Promise.all([
-          fetch('/api/wallet', {credentials:'include'}),
-          fetch('/api/transactions?currency=credit&limit=30', {credentials:'include'}),
+          fetch(`${API_BASE}/wallet`, {credentials:'include'}),
+          fetch(`${API_BASE}/transactions?currency=credit&limit=30`, {credentials:'include'}),
         ]);
         if(walletR.ok){
           const {wallet} = await walletR.json();
@@ -3724,7 +3724,7 @@ h1,h2,h3{font-weight:900;}
       const targetId = userId || profile.id;
       if(targetId){
         const method = next ? 'POST' : 'DELETE';
-        fetch(`/api/follows/${targetId}`, {method, credentials:'include'}).catch(() => {});
+        fetch(`${API_BASE}/follows/${targetId}`, {method, credentials:'include'}).catch(() => {});
       }
     }
 
@@ -4206,7 +4206,7 @@ h1,h2,h3{font-weight:900;}
       try {
         const fd = new FormData();
         fd.append('images', file);
-        const r = await fetch('/api/upload', {method:'POST', credentials:'include', body:fd});
+        const r = await fetch(`${API_BASE}/upload`, {method:'POST', credentials:'include', body:fd});
         if(!r.ok) throw new Error('อัปโหลดไม่สำเร็จ');
         const d = await r.json();
         _pendingChatImageUrl = d.urls?.[0] || null;
@@ -5243,7 +5243,7 @@ function renderFeed(){
         if(currentCategoryFilter && currentCategoryFilter !== 'all') params.set('category', currentCategoryFilter);
         if(currentMarketMode === 'buy') params.set('deal_type','buy');
         else if(currentMarketMode === 'swap') params.set('deal_type','swap');
-        const r = await fetch(`/api/items?${params}`, {credentials:'include'});
+        const r = await fetch(`${API_BASE}/items?${params}`, {credentials:'include'});
         if(!r.ok) throw new Error('failed');
         const {items: newRows, hasMore} = await r.json();
         _shopOffset += 20;
@@ -6855,7 +6855,7 @@ function renderFeed(){
       if(!host) return;
       host.innerHTML = '<div class="mini-help">กำลังโหลด...</div>';
       try {
-        const r = await fetch('/api/bookmarks', {credentials:'include'});
+        const r = await fetch(`${API_BASE}/bookmarks`, {credentials:'include'});
         if(!r.ok) throw new Error('failed');
         const {bookmarks} = await r.json();
         if(!bookmarks.length){
@@ -7269,7 +7269,7 @@ function renderFeed(){
       try {
         const fd = new FormData();
         fd.append('images', file);
-        const r = await fetch('/api/upload', {method:'POST', credentials:'include', body:fd});
+        const r = await fetch(`${API_BASE}/upload`, {method:'POST', credentials:'include', body:fd});
         if(!r.ok) throw new Error('อัปโหลดรูปไม่สำเร็จ');
         const d = await r.json();
         _pendingAvatarUrl = d.urls?.[0] || null;
@@ -7402,7 +7402,7 @@ function renderFeed(){
       const msgEl = document.getElementById('verifyEmailMsg');
       msgEl.style.display = 'none';
       try {
-        const r = await fetch('/api/auth/send-verify-email', {method:'POST', credentials:'include'});
+        const r = await fetch(`${API_BASE}/auth/send-verify-email`, {method:'POST', credentials:'include'});
         if(!r.ok){ const d=await r.json(); msgEl.textContent=d.message||'ส่ง OTP ไม่สำเร็จ'; msgEl.style.display='block'; return; }
         document.getElementById('verifyStep1').style.display = 'none';
         document.getElementById('verifyStep2').style.display = 'block';
@@ -7414,7 +7414,7 @@ function renderFeed(){
       msgEl.style.display = 'none';
       if(!code || code.length !== 6){ msgEl.textContent='กรุณากรอกรหัส 6 หลัก'; msgEl.style.display='block'; return; }
       try {
-        const r = await fetch('/api/auth/verify-email', {
+        const r = await fetch(`${API_BASE}/auth/verify-email`, {
           method:'POST', credentials:'include',
           headers:{'Content-Type':'application/json'},
           body: JSON.stringify({ userId: currentUser?.id, code }),
@@ -7444,7 +7444,7 @@ function renderFeed(){
       if(!email){ document.getElementById('forgotMsg').textContent = 'กรอกอีเมลก่อน'; document.getElementById('forgotMsg').style.display='block'; return; }
       document.getElementById('forgotMsg').style.display = 'none';
       try {
-        await fetch('/api/auth/forgot-password', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({email})});
+        await fetch(`${API_BASE}/auth/forgot-password`, {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({email})});
         document.getElementById('forgotStep1').style.display = 'none';
         document.getElementById('forgotStep2').style.display = 'block';
       } catch(e){ document.getElementById('forgotMsg').textContent = 'เกิดข้อผิดพลาด'; document.getElementById('forgotMsg').style.display='block'; }
@@ -7457,7 +7457,7 @@ function renderFeed(){
       if(code.length !== 6){ msgEl.textContent = 'รหัส OTP ต้องเป็น 6 หลัก'; msgEl.style.display='block'; return; }
       if(newPassword.length < 6){ msgEl.textContent = 'รหัสผ่านต้องมีอย่างน้อย 6 ตัว'; msgEl.style.display='block'; return; }
       try {
-        const r = await fetch('/api/auth/reset-password', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({email, code, newPassword})});
+        const r = await fetch(`${API_BASE}/auth/reset-password`, {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({email, code, newPassword})});
         const data = await r.json();
         if(!r.ok){ msgEl.textContent = data.message || 'รหัส OTP ไม่ถูกต้อง'; msgEl.style.display='block'; return; }
         closeForgotPasswordSheet();
@@ -7481,7 +7481,7 @@ function renderFeed(){
       document.getElementById('notiSettingsBackdrop')?.classList.add('open');
       document.getElementById('notiSettingsSheet')?.classList.add('open');
       try {
-        const r = await fetch('/api/notifications/settings', {credentials:'include'});
+        const r = await fetch(`${API_BASE}/notifications/settings`, {credentials:'include'});
         if(r.ok){ const d = await r.json(); _notiSettings = d.settings || {}; }
       } catch{ /* use cached */ }
       const list = document.getElementById('notiSettingsList');
@@ -7499,7 +7499,7 @@ function renderFeed(){
 
     async function saveNotificationSettings(){
       try {
-        const r = await fetch('/api/notifications/settings', {
+        const r = await fetch(`${API_BASE}/notifications/settings`, {
           method:'PATCH', credentials:'include',
           headers:{'Content-Type':'application/json'},
           body: JSON.stringify(_notiSettings),
@@ -7519,8 +7519,8 @@ function renderFeed(){
       document.getElementById('walletTxList').innerHTML = '<div style="text-align:center;color:var(--fg2);font-size:13px">กำลังโหลด...</div>';
       try {
         const [walletR, txR] = await Promise.all([
-          fetch('/api/wallet', {credentials:'include'}),
-          fetch('/api/transactions?limit=20', {credentials:'include'}),
+          fetch(`${API_BASE}/wallet`, {credentials:'include'}),
+          fetch(`${API_BASE}/transactions?limit=20`, {credentials:'include'}),
         ]);
         const {wallet} = await walletR.json();
         const {transactions} = await txR.json();
@@ -7550,7 +7550,7 @@ function renderFeed(){
       msgEl.style.display = 'none';
       if(cash === 0 && credit === 0){ msgEl.textContent='กรอกจำนวนอย่างน้อยหนึ่งช่อง'; msgEl.style.display='block'; return; }
       try {
-        const r = await fetch('/api/wallet/deposit', {
+        const r = await fetch(`${API_BASE}/wallet/deposit`, {
           method:'POST', credentials:'include',
           headers:{'Content-Type':'application/json'},
           body: JSON.stringify({ cashAmount: cash, creditAmount: credit }),
@@ -7560,7 +7560,7 @@ function renderFeed(){
         document.getElementById('depositCreditInput').value = '';
         showToast('เติมเงินสำเร็จ');
         // Refresh balances
-        const [walletR] = await Promise.all([fetch('/api/wallet', {credentials:'include'})]);
+        const [walletR] = await Promise.all([fetch(`${API_BASE}/wallet`, {credentials:'include'})]);
         const {wallet} = await walletR.json();
         document.getElementById('walletCashBalance').textContent = `฿${Number(wallet.cashBalance||0).toLocaleString('th-TH')}`;
         document.getElementById('walletCreditBalance').textContent = `${Number(wallet.creditBalance||0).toLocaleString('th-TH')} cr`;
@@ -7574,7 +7574,7 @@ function renderFeed(){
       msgEl.style.display = 'none';
       if(cash === 0 && credit === 0){ msgEl.textContent='กรอกจำนวนอย่างน้อยหนึ่งช่อง'; msgEl.style.display='block'; return; }
       try {
-        const r = await fetch('/api/wallet/withdraw', {
+        const r = await fetch(`${API_BASE}/wallet/withdraw`, {
           method:'POST', credentials:'include',
           headers:{'Content-Type':'application/json'},
           body: JSON.stringify({ cashAmount: cash, creditAmount: credit }),
@@ -7583,7 +7583,7 @@ function renderFeed(){
         document.getElementById('withdrawCashInput').value = '';
         document.getElementById('withdrawCreditInput').value = '';
         showToast('ถอนเงินสำเร็จ');
-        const walletR = await fetch('/api/wallet', {credentials:'include'});
+        const walletR = await fetch(`${API_BASE}/wallet`, {credentials:'include'});
         const {wallet} = await walletR.json();
         document.getElementById('walletCashBalance').textContent = `฿${Number(wallet.cashBalance||0).toLocaleString('th-TH')}`;
         document.getElementById('walletCreditBalance').textContent = `${Number(wallet.creditBalance||0).toLocaleString('th-TH')} cr`;
@@ -7609,7 +7609,7 @@ function renderFeed(){
       msgEl.style.display = 'none';
       if(!reportedUserId){ msgEl.textContent = 'ไม่พบ ID ผู้ถูกรายงาน'; msgEl.style.display='block'; return; }
       try {
-        const r = await fetch('/api/disputes', {method:'POST', credentials:'include', headers:{'Content-Type':'application/json'}, body:JSON.stringify({reportedUserId, reason, detail: detail||undefined})});
+        const r = await fetch(`${API_BASE}/disputes`, {method:'POST', credentials:'include', headers:{'Content-Type':'application/json'}, body:JSON.stringify({reportedUserId, reason, detail: detail||undefined})});
         if(!r.ok){ const d = await r.json(); msgEl.textContent = d.message||'ส่งรายงานไม่สำเร็จ'; msgEl.style.display='block'; return; }
         closeDisputeSheet();
         showToast('ส่งรายงานเรียบร้อย เราจะตรวจสอบโดยเร็ว');
@@ -7623,10 +7623,10 @@ function renderFeed(){
       const isBlocked = _blockedUserIds.has(userId);
       try {
         if(isBlocked){
-          const r = await fetch(`/api/blocks/${encodeURIComponent(userId)}`, {method:'DELETE', credentials:'include'});
+          const r = await fetch(`${API_BASE}/blocks/${encodeURIComponent(userId)}`, {method:'DELETE', credentials:'include'});
           if(r.ok){ _blockedUserIds.delete(userId); showToast(`ยกเลิกบล็อก ${displayName} แล้ว`); }
         } else {
-          const r = await fetch('/api/blocks', {method:'POST', credentials:'include', headers:{'Content-Type':'application/json'}, body:JSON.stringify({blockedUserId: userId})});
+          const r = await fetch(`${API_BASE}/blocks`, {method:'POST', credentials:'include', headers:{'Content-Type':'application/json'}, body:JSON.stringify({blockedUserId: userId})});
           if(r.ok){ _blockedUserIds.add(userId); showToast(`บล็อก ${displayName} แล้ว`); }
         }
         const btn = document.getElementById('blockUserBtn_' + userId) || document.getElementById('blockUserBtn_' + displayName);
@@ -7638,7 +7638,7 @@ function renderFeed(){
     async function deleteAccount(){
       if(!confirm('คุณต้องการลบบัญชีนี้ถาวรหรือไม่?\nข้อมูลส่วนตัวจะถูกลบและไม่สามารถกู้คืนได้')) return;
       try {
-        const r = await fetch('/api/auth/account', {method:'DELETE', credentials:'include'});
+        const r = await fetch(`${API_BASE}/auth/account`, {method:'DELETE', credentials:'include'});
         if(!r.ok){ const d=await r.json(); showToast(d.message||'ลบบัญชีไม่สำเร็จ'); return; }
         showToast('ลบบัญชีเรียบร้อย');
         setTimeout(() => { window.location.href = '/'; }, 1500);
@@ -7669,7 +7669,7 @@ function renderFeed(){
       if(!offerId){ msgEl.textContent='ไม่พบ ID ข้อเสนอ'; msgEl.style.display='block'; return; }
       if(cash === 0 && credit === 0){ msgEl.textContent='กรอกจำนวนเงินสดหรือเครดิต'; msgEl.style.display='block'; return; }
       try {
-        const r = await fetch(`/api/offers/${offerId}/counter`, {
+        const r = await fetch(`${API_BASE}/offers/${offerId}/counter`, {
           method:'POST', credentials:'include',
           headers:{'Content-Type':'application/json'},
           body: JSON.stringify({
@@ -7712,7 +7712,7 @@ function renderFeed(){
           if(_dlIdx >= 0){
             openDetailByIndex(_dlIdx);
           } else {
-            fetch('/api/items/' + encodeURIComponent(_deepLinkItem))
+            fetch(`${API_BASE}/items/` + encodeURIComponent(_deepLinkItem))
               .then(r => r.ok ? r.json() : null)
               .then(data => {
                 if(data?.item){

--- a/index.html
+++ b/index.html
@@ -2189,8 +2189,6 @@ h1,h2,h3{font-weight:900;}
               </div>
             </div>
             <div class="deal-dispute-actions">
-              <button class="soft" onclick="escalateFocusedDispute()">ส่งเข้า moderation</button>
-              <button class="soft" onclick="markFocusedTimeoutRisk()">mark timeout risk</button>
               <button class="soft" onclick="resolveFocusedDispute()">resolve issue</button>
             </div>
           </section>
@@ -2701,7 +2699,15 @@ h1,h2,h3{font-weight:900;}
           <div class="menu-item"><div class="menu-icon"><svg><use href="#i-chat"/></svg></div><div class="menu-copy"><strong>Inbox และดีล</strong><span>ดูดีลที่ต้องตัดสินใจและแชททั้งหมด</span></div><div class="menu-right"><svg><use href="#i-arrow"/></svg></div></div>
           <div class="menu-item" onclick="closeProfileSettings(); openWalletSheet()" style="cursor:pointer"><div class="menu-icon"><svg><use href="#i-credit"/></svg></div><div class="menu-copy"><strong>กระเป๋าเงิน</strong><span>ยอดคงเหลือ ประวัติธุรกรรม</span></div><div class="menu-right"><svg><use href="#i-arrow"/></svg></div></div>
         </div>
-        <div class="menu-group-title" style="margin-top:18px">บัญชี</div>
+        <div class="menu-group-title" style="margin-top:18px">แก้ไขโปรไฟล์</div>
+        <div class="settings-edit-form" style="display:flex;flex-direction:column;gap:10px;padding:4px 0 12px">
+          <div class="field"><label style="font-size:12px;font-weight:700;color:var(--muted);display:block;margin-bottom:4px">ชื่อที่แสดง</label><input id="editDisplayName" type="text" placeholder="ชื่อที่แสดงในโปรไฟล์" style="width:100%;padding:10px 12px;border:1.5px solid var(--border);border-radius:12px;font-size:14px;background:var(--input-bg,#f5f5f5)"></div>
+          <div class="field"><label style="font-size:12px;font-weight:700;color:var(--muted);display:block;margin-bottom:4px">Username</label><input id="editUsername" type="text" placeholder="@username" style="width:100%;padding:10px 12px;border:1.5px solid var(--border);border-radius:12px;font-size:14px;background:var(--input-bg,#f5f5f5)"></div>
+          <div class="field"><label style="font-size:12px;font-weight:700;color:var(--muted);display:block;margin-bottom:4px">เมือง</label><input id="editCity" type="text" placeholder="เช่น Bangkok" style="width:100%;padding:10px 12px;border:1.5px solid var(--border);border-radius:12px;font-size:14px;background:var(--input-bg,#f5f5f5)"></div>
+          <div class="field"><label style="font-size:12px;font-weight:700;color:var(--muted);display:block;margin-bottom:4px">URL รูปโปรไฟล์</label><input id="editAvatarUrl" type="url" placeholder="https://..." style="width:100%;padding:10px 12px;border:1.5px solid var(--border);border-radius:12px;font-size:14px;background:var(--input-bg,#f5f5f5)"></div>
+          <button class="primary-btn" type="button" onclick="saveProfile()" style="margin-top:4px">บันทึกโปรไฟล์</button>
+        </div>
+        <div class="menu-group-title" style="margin-top:4px">บัญชี</div>
         <button class="logout-btn" onclick="closeProfileSettings(); signOut()">ออกจากระบบ</button>
         <button class="logout-btn" style="color:#e53e3e;margin-top:8px" onclick="closeProfileSettings(); deleteAccount()">ลบบัญชีถาวร</button>
       </div>
@@ -3132,6 +3138,11 @@ h1,h2,h3{font-weight:900;}
           }));
         }
 
+        if(currentUser){
+          await loadWalletData();
+          await loadNotificationsData();
+        }
+
         const hasLiveRecords = apiItems.length > 0 || apiOffers.length > 0;
         if(!hasLiveRecords){
           apiHydrationError = '';
@@ -3344,6 +3355,28 @@ h1,h2,h3{font-weight:900;}
         Object.keys(chatThreads).forEach((key) => delete chatThreads[key]);
         Object.assign(chatThreads, chatMap);
 
+        if(currentUser){
+          const convsResp = await fetch(`${API_BASE}/chat/conversations`, {credentials:'include'}).catch(() => null);
+          const convsJson = convsResp?.ok ? await convsResp.json() : {conversations:[]};
+          (convsJson.conversations || []).forEach(conv => {
+            const otherId = conv.participantAId === currentUser.id ? conv.participantBId : conv.participantAId;
+            const otherName = (conv.otherParticipant?.displayName || conv.otherParticipant?.username) || profileMap.get(otherId) || profileLabelFromId(otherId);
+            if(!chatThreads[otherName]){
+              chatThreads[otherName] = {
+                name: otherName,
+                img: conv.otherParticipant?.avatarUrl || avatarDataUri(otherName),
+                targetTitle: conv.deal?.targetItem?.title || 'ดีลบน QXwap',
+                dealStatus: conv.deal?.stage || 'pending',
+                dealSub: 'ดีลล่าสุดสำหรับ ' + (conv.deal?.targetItem?.title || 'สินค้า'),
+                quickReplies: ['โอเคครับ', 'ขอรูปเพิ่มหน่อย', 'นัดรับได้'],
+                messages: []
+              };
+            }
+            chatThreads[otherName].conversationId = conv.id;
+          });
+        }
+
+
         if(typeof savedFeedItems !== 'undefined'){
           savedFeedItems.clear();
           savedOfferByItemId.clear();
@@ -3373,8 +3406,8 @@ h1,h2,h3{font-weight:900;}
       go('credit');
       try {
         const [walletR, txR] = await Promise.all([
-          fetch('/api/wallet', {credentials:'include'}),
-          fetch('/api/transactions?currency=credit&limit=30', {credentials:'include'}),
+          fetch(`${API_BASE}/wallet`, {credentials:'include'}),
+          fetch(`${API_BASE}/transactions?currency=credit&limit=30`, {credentials:'include'}),
         ]);
         if(walletR.ok){
           const {wallet} = await walletR.json();
@@ -3417,6 +3450,61 @@ h1,h2,h3{font-weight:900;}
             <strong class="credit-log-value ${item.type}">${item.value}</strong>
           </div>
         </div>`).join('');
+    }
+
+    async function loadWalletData(){
+      try{
+        const [walletResp, txResp] = await Promise.all([
+          fetch(`${API_BASE}/wallet`, {credentials:'include'}),
+          fetch(`${API_BASE}/transactions?currency=credit&limit=20`, {credentials:'include'})
+        ]);
+        if(walletResp.ok){
+          const { wallet } = await walletResp.json();
+          creditState.balance = Math.round(Number(wallet.balanceCredit) || 0);
+        }
+        if(txResp.ok){
+          const { transactions } = await txResp.json();
+          const mapped = (transactions || []).map(tx => {
+            const amt = Number(tx.amount) || 0;
+            const typeLabel = tx.type === 'transfer' ? 'โอนเครดิต' : tx.type === 'lock' ? 'พักเครดิต escrow' : 'คืนเครดิต';
+            return {
+              title: tx.note || typeLabel,
+              meta: relativeTimeFromApi(tx.createdAt),
+              value: `${amt >= 0 ? '+' : ''}${formatAmount(Math.abs(amt))}`,
+              type: amt >= 0 ? 'plus' : 'minus'
+            };
+          });
+          if(mapped.length > 0) creditLog.splice(0, creditLog.length, ...mapped);
+        }
+        renderCreditSummary();
+        renderCreditLog();
+      }catch(e){ /* keep existing */ }
+    }
+
+    async function loadNotificationsData(){
+      try{
+        const resp = await fetch(`${API_BASE}/notifications`, {credentials:'include'});
+        if(!resp.ok) return;
+        const { notifications } = await resp.json();
+        const iconMap = {
+          offer_received:'bell', offer_accepted:'star', offer_rejected:'bell',
+          offer_cancelled:'bell', offer_confirmed:'check',
+          deal_stage_updated:'feed', shipment_updated:'feed', trade_completed:'star'
+        };
+        const mapped = (notifications || []).map(n => ({
+          id: n.id,
+          icon: iconMap[n.type] || 'bell',
+          title: n.title,
+          sub: n.body || '',
+          time: relativeTimeFromApi(n.createdAt),
+          unread: !n.isRead,
+          targetIndex: 0
+        }));
+        const unread = mapped.filter(n => n.unread);
+        const read = mapped.filter(n => !n.unread);
+        notiNew.splice(0, notiNew.length, ...unread.slice(0, 10));
+        notiEarlier.splice(0, notiEarlier.length, ...read.slice(0, 20));
+      }catch(e){ /* keep existing */ }
     }
 
     function openProfileByName(name){
@@ -3636,7 +3724,7 @@ h1,h2,h3{font-weight:900;}
       const targetId = userId || profile.id;
       if(targetId){
         const method = next ? 'POST' : 'DELETE';
-        fetch(`/api/follows/${targetId}`, {method, credentials:'include'}).catch(() => {});
+        fetch(`${API_BASE}/follows/${targetId}`, {method, credentials:'include'}).catch(() => {});
       }
     }
 
@@ -3929,24 +4017,42 @@ h1,h2,h3{font-weight:900;}
 
     async function loadChatMessages(name){
       const thread = chatThreads[name];
-      if(!thread?.offerId) return;
-      try {
-        const r = await fetch(`/api/chats/${thread.offerId}`, {credentials:'include'});
-        if(!r.ok) return;
-        const data = await r.json();
-        const msgs = data.messages || [];
-        if(msgs.length > 0){
-          thread.messages = msgs.map(m => ({
-            side: m.senderId === currentUser?.id ? 'self' : 'other',
-            text: m.message,
-            time: relativeTimeFromApi(m.createdAt),
-            id: m.id,
-          }));
-          renderChatScreen(thread);
-          const host = document.getElementById('chatThread');
-          if(host) host.scrollTop = host.scrollHeight;
+      if(!thread?.conversationId) return;
+      try{
+        const resp = await fetch(`${API_BASE}/chat/conversations/${thread.conversationId}/messages`, {credentials:'include'});
+        if(resp.ok){
+          const { messages } = await resp.json();
+          if(messages && messages.length > 0){
+            thread.messages = messages.map(m => ({
+              side: m.senderId === currentUser?.id ? 'self' : 'other',
+              text: m.content,
+              time: relativeTimeFromApi(m.createdAt)
+            }));
+            renderChatScreen(thread);
+            const host = document.getElementById('chatThread');
+            if(host) host.scrollTop = host.scrollHeight;
+          }
         }
-      } catch(e) { /* ignore */ }
+      }catch(e){}
+      if(supabaseClient){
+        if(chatSubscription) supabaseClient.removeChannel(chatSubscription);
+        chatSubscription = supabaseClient
+          .channel('chat:' + thread.conversationId)
+          .on('postgres_changes', {
+            event: 'INSERT', schema: 'public', table: 'messages',
+            filter: 'conversation_id=eq.' + thread.conversationId,
+          }, (payload) => {
+            const msg = payload.new;
+            if(!msg || msg.sender_id === currentUser?.id) return;
+            const t = chatThreads[appState.activeChatName];
+            if(!t || t.conversationId !== thread.conversationId) return;
+            t.messages.push({ side: 'other', text: msg.content || msg.text, time: 'ตอนนี้' });
+            renderChatScreen(t);
+            const h = document.getElementById('chatThread');
+            if(h) h.scrollTop = h.scrollHeight;
+          })
+          .subscribe();
+      }
     }
 
     function openChatByName(name){
@@ -4100,7 +4206,7 @@ h1,h2,h3{font-weight:900;}
       try {
         const fd = new FormData();
         fd.append('images', file);
-        const r = await fetch('/api/upload', {method:'POST', credentials:'include', body:fd});
+        const r = await fetch(`${API_BASE}/upload`, {method:'POST', credentials:'include', body:fd});
         if(!r.ok) throw new Error('อัปโหลดไม่สำเร็จ');
         const d = await r.json();
         _pendingChatImageUrl = d.urls?.[0] || null;
@@ -4123,12 +4229,11 @@ h1,h2,h3{font-weight:900;}
       renderChatScreen(thread);
       const host = document.getElementById('chatThread');
       if(host) host.scrollTop = host.scrollHeight;
-      if(thread.offerId && currentUser?.id){
-        const body = { offerId: thread.offerId, message: value || undefined, imageUrl: imageUrl || undefined };
-        fetch('/api/messages', {
-          method:'POST', credentials:'include',
-          headers:{'Content-Type':'application/json'},
-          body: JSON.stringify(body)
+      if(thread.conversationId){
+        fetch(`${API_BASE}/chat/conversations/${thread.conversationId}/messages`, {
+          method: 'POST', credentials: 'include',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({content: value})
         }).then(r => { if(!r.ok) showToast('ส่งข้อความไม่สำเร็จ'); })
           .catch(() => showToast('ส่งข้อความไม่สำเร็จ'));
       }
@@ -4683,6 +4788,58 @@ function renderFeed(){
       document.getElementById('profileSettingsBackdrop')?.classList.add('open');
       document.getElementById('profileSettingsSheet')?.classList.add('open');
       document.body.style.overflow = 'hidden';
+      const self = profileDirectory.self;
+      if(self){
+        const nameInput = document.getElementById('editDisplayName');
+        const usernameInput = document.getElementById('editUsername');
+        const cityInput = document.getElementById('editCity');
+        const avatarInput = document.getElementById('editAvatarUrl');
+        if(nameInput) nameInput.value = self.name || '';
+        if(usernameInput) usernameInput.value = (self.handle || '').replace(/^@/,'');
+        if(cityInput) cityInput.value = self.city || '';
+        if(avatarInput) avatarInput.value = (self.img && !self.img.startsWith('data:')) ? self.img : '';
+      }
+    }
+
+    async function saveProfile(){
+      const displayName = document.getElementById('editDisplayName')?.value?.trim();
+      const username = document.getElementById('editUsername')?.value?.trim();
+      const city = document.getElementById('editCity')?.value?.trim();
+      const avatarUrl = document.getElementById('editAvatarUrl')?.value?.trim();
+      const payload = {};
+      if(displayName) payload.displayName = displayName;
+      if(username) payload.username = username;
+      if(city) payload.city = city;
+      if(avatarUrl) payload.avatarUrl = avatarUrl;
+      if(!Object.keys(payload).length){ showToast('ไม่มีข้อมูลที่ต้องบันทึก'); return; }
+      const btn = document.querySelector('#profileSettingsSheet .primary-btn');
+      const orig = btn?.textContent;
+      if(btn) btn.textContent = 'กำลังบันทึก…';
+      try {
+        const resp = await fetch(`${API_BASE}/profiles/me`, {
+          method:'PATCH',
+          credentials:'include',
+          headers:{'Content-Type':'application/json'},
+          body:JSON.stringify(payload)
+        });
+        const data = await resp.json();
+        if(!resp.ok) throw new Error(data?.error || `HTTP ${resp.status}`);
+        const p = data.profile;
+        profileDirectory.self = {
+          ...profileDirectory.self,
+          name: p.displayName || p.username || profileDirectory.self.name,
+          handle: `@${p.username || (p.displayName||'').toLowerCase().replace(/\s+/g,'')||'me'}`,
+          city: p.city || profileDirectory.self.city,
+          img: p.avatarUrl || profileDirectory.self.img,
+        };
+        renderProfileCurrentState();
+        showToast('บันทึกโปรไฟล์แล้ว');
+        closeProfileSettings();
+      } catch(err){
+        showToast('บันทึกไม่สำเร็จ: ' + String(err?.message || err));
+      } finally {
+        if(btn && orig) btn.textContent = orig;
+      }
     }
 
     function closeProfileSettings(){
@@ -4782,8 +4939,8 @@ function renderFeed(){
               </div>
             </div>
             <div class="btn-row composer-actions">
-              <button class="soft-btn" type="button" onclick="resetAddDraft()">รีเซ็ต</button>
-              <button class="primary-btn" type="button" onclick="submitAddProduct()">โพสต์สินค้า</button>
+              <button class="soft-btn" type="button" onclick="resetAddDraft()">${appState.editingItemId ? 'ยกเลิก' : 'รีเซ็ต'}</button>
+              <button class="primary-btn" type="button" onclick="submitAddProduct()">${appState.editingItemId ? 'บันทึกการแก้ไข' : 'โพสต์สินค้า'}</button>
             </div>
           </div>`;
       } catch(e){
@@ -4834,6 +4991,7 @@ function renderFeed(){
     function resetAddDraft(){
       appState.addDraft = null;
       appState.addImages = [];
+      appState.editingItemId = null;
       renderAddScreenSafe();
     }
 
@@ -4914,6 +5072,42 @@ function renderFeed(){
       go('login', true);
     }
 
+    function openEditProductScreen(itemId){
+      if(!currentUser){ showToast('กรุณาเข้าสู่ระบบก่อน'); return; }
+      const item = feedItems.find(x => x.apiItemId === itemId);
+      if(!item){ showToast('ไม่พบสินค้านี้'); return; }
+      appState.editingItemId = itemId;
+      appState.addDraft = {
+        title: item.title || '',
+        description: '',
+        category: item.category || 'gadget',
+        dealType: item.mode === 'buy' ? 'buy' : item.mode === 'both' ? 'both' : 'swap',
+        priceCash: item.priceCash != null ? String(item.priceCash) : '',
+        priceCredit: item.priceCredit != null ? String(item.priceCredit) : '',
+        wantedText: item.wantedText || item.wantTitle || '',
+        location: item.meta || 'Bangkok'
+      };
+      appState.addSelectedImages = item.imageUrls ? [...item.imageUrls] : [];
+      openAddProductScreen(false);
+    }
+
+    async function deleteProduct(itemId){
+      if(!currentUser){ showToast('กรุณาเข้าสู่ระบบก่อน'); return; }
+      if(!confirm('ต้องการลบสินค้านี้หรือไม่?')) return;
+      try{
+        const resp = await fetch(`${API_BASE}/items/${itemId}`, {method:'DELETE', credentials:'include'});
+        if(!resp.ok){
+          const err = await resp.json().catch(() => ({}));
+          throw new Error(err.error || 'ลบสินค้าไม่สำเร็จ');
+        }
+        showToast('ลบสินค้าแล้ว');
+        await hydrateFromApi(true);
+        renderProducts();
+      }catch(e){
+        showToast(String(e?.message || 'ลบสินค้าไม่สำเร็จ'));
+      }
+    }
+
     function openAddProductScreen(skipHistory=false){
       console.log('[add] click');
       if(!currentUser){
@@ -4948,38 +5142,38 @@ function renderFeed(){
     async function submitAddProduct(){
       const draft = ensureAddProductState();
       const title = String(draft.title || '').trim();
-      if(!title){
-        showToast('กรอกชื่อสินค้าก่อนโพสต์');
-        return;
-      }
+      if(!title){ showToast('กรอกชื่อสินค้าก่อนโพสต์'); return; }
       const priceCash = Math.max(0, Number(draft.priceCash || 0));
       const priceCredit = Math.max(0, Number(draft.priceCredit || 0));
       const wantedText = String(draft.wantedText || '').trim();
       const description = String(draft.description || '').trim();
       const dealType = String(draft.dealType || 'swap');
+      const editingId = appState.editingItemId || null;
       const btn = document.querySelector('#addScreenContent .primary-btn');
-      if(btn){ btn.disabled = true; btn.textContent = 'กำลังโพสต์…'; }
+      if(btn){ btn.disabled = true; btn.textContent = editingId ? 'กำลังบันทึก…' : 'กำลังโพสต์…'; }
       try {
         // Upload any locally-selected images first
-        const pending = appState.addImages.filter(img => img.file && !img.url);
-        if(pending.length > 0){
-          if(btn) btn.textContent = 'กำลังอัพโหลดรูป…';
-          try {
-            const formData = new FormData();
-            pending.forEach(img => formData.append('images', img.file));
-            const upResp = await fetch(`${API_BASE}/upload`, {method:'POST', credentials:'include', body:formData});
-            if(!upResp.ok){
-              const upErr = await upResp.json().catch(() => ({}));
-              throw new Error(upErr.error || apiErrorMessage(upResp.status));
+        if(!editingId){
+          const pending = appState.addImages.filter(img => img.file && !img.url);
+          if(pending.length > 0){
+            if(btn) btn.textContent = 'กำลังอัพโหลดรูป…';
+            try {
+              const formData = new FormData();
+              pending.forEach(img => formData.append('images', img.file));
+              const upResp = await fetch(`${API_BASE}/upload`, {method:'POST', credentials:'include', body:formData});
+              if(!upResp.ok){
+                const upErr = await upResp.json().catch(() => ({}));
+                throw new Error(upErr.error || apiErrorMessage(upResp.status));
+              }
+              const {urls} = await upResp.json();
+              pending.forEach((img, i) => { img.url = urls[i] || null; });
+              renderAddScreenSafe();
+            } catch(upErr) {
+              showToast(`อัพโหลดรูปไม่สำเร็จ: ${upErr?.message || 'ลองใหม่'} — โพสต์โดยไม่มีรูป`);
             }
-            const {urls} = await upResp.json();
-            pending.forEach((img, i) => { img.url = urls[i] || null; });
-            renderAddScreenSafe();
-          } catch(upErr) {
-            showToast(`อัพโหลดรูปไม่สำเร็จ: ${upErr?.message || 'ลองใหม่'} — โพสต์โดยไม่มีรูป`);
           }
+          if(btn) btn.textContent = 'กำลังโพสต์…';
         }
-        if(btn) btn.textContent = 'กำลังโพสต์…';
         const payload = {
           title,
           category: String(draft.category || 'gadget'),
@@ -4993,25 +5187,23 @@ function renderFeed(){
         };
         if(description) payload.description = description;
         if(wantedText) payload.wantedText = wantedText;
-        const createResp = await fetch(`${API_BASE}/items`, {
-          method: 'POST',
-          credentials: 'include',
-          headers: {'Content-Type':'application/json'},
-          body: JSON.stringify(payload),
-        });
-        if(!createResp.ok){
-          if(createResp.status === 401){ go('login', true); throw new Error(apiErrorMessage(401)); }
-          const errJson = await createResp.json().catch(() => ({}));
-          throw new Error(errJson.error || apiErrorMessage(createResp.status));
+        const url = editingId ? `${API_BASE}/items/${editingId}` : `${API_BASE}/items`;
+        const method = editingId ? 'PATCH' : 'POST';
+        const resp = await fetch(url, {method, credentials:'include', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload)});
+        if(!resp.ok){
+          if(resp.status === 401){ go('login', true); throw new Error(apiErrorMessage(401)); }
+          const errJson = await resp.json().catch(() => ({}));
+          throw new Error(errJson.error || apiErrorMessage(resp.status));
         }
-        showToast('เพิ่มสินค้าแล้ว');
+        showToast(editingId ? 'บันทึกการแก้ไขแล้ว' : 'เพิ่มสินค้าแล้ว');
+        appState.editingItemId = null;
         resetAddDraft();
         await hydrateFromApi(true);
         openMyProfile();
-      } catch(err) {
-        showToast(String(err?.message || 'โพสต์สินค้าไม่สำเร็จ'));
-      } finally {
-        if(btn){ btn.disabled = false; btn.textContent = 'โพสต์สินค้า'; }
+      }catch(err){
+        showToast(String(err?.message || 'ไม่สำเร็จ'));
+      }finally{
+        if(btn){ btn.disabled = false; btn.textContent = appState.editingItemId ? 'บันทึกการแก้ไข' : 'โพสต์สินค้า'; }
       }
     }
 
@@ -5024,13 +5216,16 @@ function renderFeed(){
       if(!grid) return;
       const items = filteredProducts();
       if(!items.length){
-        grid.innerHTML = `<div class="empty" style="grid-column:1/-1"><strong>ยังไม่มีสินค้าในตอนนี้</strong></div>`;
+        grid.innerHTML = `<div class="empty" style="grid-column:1/-1"><strong>ยังไม่มีสินค้าในตอนนี้</strong><div class="sub" style="margin-top:6px">ลองโพสต์สินค้าของคุณเพื่อเริ่มแลกเปลี่ยน</div></div>`;
         document.getElementById('shopLoadMore').style.display = 'none';
         return;
       }
       grid.innerHTML = items.map(item => {
         const idx = feedItems.findIndex(x => x.title === item.title && x.owner === item.owner);
-        return buildProductCardHTML(item, idx);
+        const ownerBtns = item.apiItemId
+          ? `<button class="soft-btn" style="flex:1" onclick="event.stopPropagation();openEditProductScreen('${attrEscape(item.apiItemId)}')">แก้ไข</button><button class="warn-btn" style="flex:1" onclick="event.stopPropagation();deleteProduct('${attrEscape(item.apiItemId)}')">ลบ</button>`
+          : `<button class="swap-now-btn full" onclick="event.stopPropagation();openDetailByIndex(${idx})">ดูรายละเอียด</button>`;
+        return buildProductCardHTML(item, idx, {actionButtons: ownerBtns});
       }).join('');
       setupMediaLoading(grid);
       // show Load More if API has more beyond what's in feedItems
@@ -5048,7 +5243,7 @@ function renderFeed(){
         if(currentCategoryFilter && currentCategoryFilter !== 'all') params.set('category', currentCategoryFilter);
         if(currentMarketMode === 'buy') params.set('deal_type','buy');
         else if(currentMarketMode === 'swap') params.set('deal_type','swap');
-        const r = await fetch(`/api/items?${params}`, {credentials:'include'});
+        const r = await fetch(`${API_BASE}/items?${params}`, {credentials:'include'});
         if(!r.ok) throw new Error('failed');
         const {items: newRows, hasMore} = await r.json();
         _shopOffset += 20;
@@ -5766,25 +5961,15 @@ function renderFeed(){
       notiNew.unshift({icon:'bell', title:`ดีล ${item.title} ${type === 'accept' ? 'ถูกยอมรับ' : type === 'reject' ? 'ถูกปฏิเสธ' : 'อัปเดตขั้นตอนใหม่'}`, sub:`${userName} · ${toastCopy || buildOfferText(request)}`, time:'ตอนนี้', unread:true, targetIndex:ctx.itemIndex});
 
       if(request.offerId && (type === 'accept' || type === 'reject')){
-        const nextStatus = type === 'accept' ? 'accepted' : 'rejected';
-        supabaseClient
-          .from('offers')
-          .update({ status: nextStatus })
-          .eq('id', request.offerId)
-          .then(async () => {
-            if(nextStatus === 'accepted' && request.senderId && currentUser?.id){
-              const [pA, pB] = [currentUser.id, request.senderId].sort();
-              await supabaseClient.from('conversations').upsert({
-                offer_id: request.offerId,
-                participant_a: pA,
-                participant_b: pB,
-                last_message: '',
-              }, { onConflict: 'offer_id' }).catch(() => {});
-            }
-            return hydrateFromApi(true);
-          })
-          .then(() => syncDealUi())
-          .catch(() => {});
+        const endpoint = type === 'accept' ? 'accept' : 'reject';
+        fetch(`${API_BASE}/offers/${request.offerId}/${endpoint}`, {
+          method: 'POST', credentials: 'include',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({})
+        })
+        .then(() => hydrateFromApi(true))
+        .then(() => syncDealUi())
+        .catch(() => {});
       }
 
       return true;
@@ -6109,7 +6294,7 @@ function renderFeed(){
           <div class="deal-summary-thumb media-loading"><img src="${item.haveImg}" alt=""><span class="deal-user-chip"><img src="${request.img}" alt=""></span></div>
           <div class="grow">
             <div class="deal-summary-title">${item.haveTitle} ↔ ${offerText}</div>
-            <div class="deal-summary-sub">ดีล mockup ของ ${request.name} ที่แยกออกจาก product detail แล้ว เพื่อให้เห็น next action, logistics และ dispute ในหน้าเดียว</div>
+            <div class="deal-summary-sub">${request.name} · ${request.time || ''}</div>
             <div class="deal-pill-row">
               <span>${statusInfo.label}</span>
               <span>${formatDeliveryMethod(request.deliveryMethod)}</span>
@@ -6255,7 +6440,7 @@ function renderFeed(){
         <div class="deal-detail-summary-top">
           <div class="deal-detail-thumb media-loading"><img src="${item.haveImg}" alt=""><span class="deal-user-chip"><img src="${request.img}" alt=""></span></div>
           <div class="grow">
-            <div class="deal-detail-kicker">ดีล mockup ที่กำลังโฟกัส</div>
+            <div class="deal-detail-kicker">ดีลที่กำลังโฟกัส</div>
             <div class="deal-detail-title">${item.haveTitle} ↔ ${offerText}</div>
             <div class="deal-detail-sub">${request.name} · ${request.time || 'ตอนนี้'} · ${statusInfo.label} · ${statusInfo.sub}</div>
           </div>
@@ -6670,7 +6855,7 @@ function renderFeed(){
       if(!host) return;
       host.innerHTML = '<div class="mini-help">กำลังโหลด...</div>';
       try {
-        const r = await fetch('/api/bookmarks', {credentials:'include'});
+        const r = await fetch(`${API_BASE}/bookmarks`, {credentials:'include'});
         if(!r.ok) throw new Error('failed');
         const {bookmarks} = await r.json();
         if(!bookmarks.length){
@@ -7084,7 +7269,7 @@ function renderFeed(){
       try {
         const fd = new FormData();
         fd.append('images', file);
-        const r = await fetch('/api/upload', {method:'POST', credentials:'include', body:fd});
+        const r = await fetch(`${API_BASE}/upload`, {method:'POST', credentials:'include', body:fd});
         if(!r.ok) throw new Error('อัปโหลดรูปไม่สำเร็จ');
         const d = await r.json();
         _pendingAvatarUrl = d.urls?.[0] || null;
@@ -7217,7 +7402,7 @@ function renderFeed(){
       const msgEl = document.getElementById('verifyEmailMsg');
       msgEl.style.display = 'none';
       try {
-        const r = await fetch('/api/auth/send-verify-email', {method:'POST', credentials:'include'});
+        const r = await fetch(`${API_BASE}/auth/send-verify-email`, {method:'POST', credentials:'include'});
         if(!r.ok){ const d=await r.json(); msgEl.textContent=d.message||'ส่ง OTP ไม่สำเร็จ'; msgEl.style.display='block'; return; }
         document.getElementById('verifyStep1').style.display = 'none';
         document.getElementById('verifyStep2').style.display = 'block';
@@ -7229,7 +7414,7 @@ function renderFeed(){
       msgEl.style.display = 'none';
       if(!code || code.length !== 6){ msgEl.textContent='กรุณากรอกรหัส 6 หลัก'; msgEl.style.display='block'; return; }
       try {
-        const r = await fetch('/api/auth/verify-email', {
+        const r = await fetch(`${API_BASE}/auth/verify-email`, {
           method:'POST', credentials:'include',
           headers:{'Content-Type':'application/json'},
           body: JSON.stringify({ userId: currentUser?.id, code }),
@@ -7259,7 +7444,7 @@ function renderFeed(){
       if(!email){ document.getElementById('forgotMsg').textContent = 'กรอกอีเมลก่อน'; document.getElementById('forgotMsg').style.display='block'; return; }
       document.getElementById('forgotMsg').style.display = 'none';
       try {
-        await fetch('/api/auth/forgot-password', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({email})});
+        await fetch(`${API_BASE}/auth/forgot-password`, {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({email})});
         document.getElementById('forgotStep1').style.display = 'none';
         document.getElementById('forgotStep2').style.display = 'block';
       } catch(e){ document.getElementById('forgotMsg').textContent = 'เกิดข้อผิดพลาด'; document.getElementById('forgotMsg').style.display='block'; }
@@ -7272,7 +7457,7 @@ function renderFeed(){
       if(code.length !== 6){ msgEl.textContent = 'รหัส OTP ต้องเป็น 6 หลัก'; msgEl.style.display='block'; return; }
       if(newPassword.length < 6){ msgEl.textContent = 'รหัสผ่านต้องมีอย่างน้อย 6 ตัว'; msgEl.style.display='block'; return; }
       try {
-        const r = await fetch('/api/auth/reset-password', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({email, code, newPassword})});
+        const r = await fetch(`${API_BASE}/auth/reset-password`, {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({email, code, newPassword})});
         const data = await r.json();
         if(!r.ok){ msgEl.textContent = data.message || 'รหัส OTP ไม่ถูกต้อง'; msgEl.style.display='block'; return; }
         closeForgotPasswordSheet();
@@ -7296,7 +7481,7 @@ function renderFeed(){
       document.getElementById('notiSettingsBackdrop')?.classList.add('open');
       document.getElementById('notiSettingsSheet')?.classList.add('open');
       try {
-        const r = await fetch('/api/notifications/settings', {credentials:'include'});
+        const r = await fetch(`${API_BASE}/notifications/settings`, {credentials:'include'});
         if(r.ok){ const d = await r.json(); _notiSettings = d.settings || {}; }
       } catch{ /* use cached */ }
       const list = document.getElementById('notiSettingsList');
@@ -7314,7 +7499,7 @@ function renderFeed(){
 
     async function saveNotificationSettings(){
       try {
-        const r = await fetch('/api/notifications/settings', {
+        const r = await fetch(`${API_BASE}/notifications/settings`, {
           method:'PATCH', credentials:'include',
           headers:{'Content-Type':'application/json'},
           body: JSON.stringify(_notiSettings),
@@ -7334,8 +7519,8 @@ function renderFeed(){
       document.getElementById('walletTxList').innerHTML = '<div style="text-align:center;color:var(--fg2);font-size:13px">กำลังโหลด...</div>';
       try {
         const [walletR, txR] = await Promise.all([
-          fetch('/api/wallet', {credentials:'include'}),
-          fetch('/api/transactions?limit=20', {credentials:'include'}),
+          fetch(`${API_BASE}/wallet`, {credentials:'include'}),
+          fetch(`${API_BASE}/transactions?limit=20`, {credentials:'include'}),
         ]);
         const {wallet} = await walletR.json();
         const {transactions} = await txR.json();
@@ -7365,7 +7550,7 @@ function renderFeed(){
       msgEl.style.display = 'none';
       if(cash === 0 && credit === 0){ msgEl.textContent='กรอกจำนวนอย่างน้อยหนึ่งช่อง'; msgEl.style.display='block'; return; }
       try {
-        const r = await fetch('/api/wallet/deposit', {
+        const r = await fetch(`${API_BASE}/wallet/deposit`, {
           method:'POST', credentials:'include',
           headers:{'Content-Type':'application/json'},
           body: JSON.stringify({ cashAmount: cash, creditAmount: credit }),
@@ -7375,7 +7560,7 @@ function renderFeed(){
         document.getElementById('depositCreditInput').value = '';
         showToast('เติมเงินสำเร็จ');
         // Refresh balances
-        const [walletR] = await Promise.all([fetch('/api/wallet', {credentials:'include'})]);
+        const [walletR] = await Promise.all([fetch(`${API_BASE}/wallet`, {credentials:'include'})]);
         const {wallet} = await walletR.json();
         document.getElementById('walletCashBalance').textContent = `฿${Number(wallet.cashBalance||0).toLocaleString('th-TH')}`;
         document.getElementById('walletCreditBalance').textContent = `${Number(wallet.creditBalance||0).toLocaleString('th-TH')} cr`;
@@ -7389,7 +7574,7 @@ function renderFeed(){
       msgEl.style.display = 'none';
       if(cash === 0 && credit === 0){ msgEl.textContent='กรอกจำนวนอย่างน้อยหนึ่งช่อง'; msgEl.style.display='block'; return; }
       try {
-        const r = await fetch('/api/wallet/withdraw', {
+        const r = await fetch(`${API_BASE}/wallet/withdraw`, {
           method:'POST', credentials:'include',
           headers:{'Content-Type':'application/json'},
           body: JSON.stringify({ cashAmount: cash, creditAmount: credit }),
@@ -7398,7 +7583,7 @@ function renderFeed(){
         document.getElementById('withdrawCashInput').value = '';
         document.getElementById('withdrawCreditInput').value = '';
         showToast('ถอนเงินสำเร็จ');
-        const walletR = await fetch('/api/wallet', {credentials:'include'});
+        const walletR = await fetch(`${API_BASE}/wallet`, {credentials:'include'});
         const {wallet} = await walletR.json();
         document.getElementById('walletCashBalance').textContent = `฿${Number(wallet.cashBalance||0).toLocaleString('th-TH')}`;
         document.getElementById('walletCreditBalance').textContent = `${Number(wallet.creditBalance||0).toLocaleString('th-TH')} cr`;
@@ -7424,7 +7609,7 @@ function renderFeed(){
       msgEl.style.display = 'none';
       if(!reportedUserId){ msgEl.textContent = 'ไม่พบ ID ผู้ถูกรายงาน'; msgEl.style.display='block'; return; }
       try {
-        const r = await fetch('/api/disputes', {method:'POST', credentials:'include', headers:{'Content-Type':'application/json'}, body:JSON.stringify({reportedUserId, reason, detail: detail||undefined})});
+        const r = await fetch(`${API_BASE}/disputes`, {method:'POST', credentials:'include', headers:{'Content-Type':'application/json'}, body:JSON.stringify({reportedUserId, reason, detail: detail||undefined})});
         if(!r.ok){ const d = await r.json(); msgEl.textContent = d.message||'ส่งรายงานไม่สำเร็จ'; msgEl.style.display='block'; return; }
         closeDisputeSheet();
         showToast('ส่งรายงานเรียบร้อย เราจะตรวจสอบโดยเร็ว');
@@ -7438,10 +7623,10 @@ function renderFeed(){
       const isBlocked = _blockedUserIds.has(userId);
       try {
         if(isBlocked){
-          const r = await fetch(`/api/blocks/${encodeURIComponent(userId)}`, {method:'DELETE', credentials:'include'});
+          const r = await fetch(`${API_BASE}/blocks/${encodeURIComponent(userId)}`, {method:'DELETE', credentials:'include'});
           if(r.ok){ _blockedUserIds.delete(userId); showToast(`ยกเลิกบล็อก ${displayName} แล้ว`); }
         } else {
-          const r = await fetch('/api/blocks', {method:'POST', credentials:'include', headers:{'Content-Type':'application/json'}, body:JSON.stringify({blockedUserId: userId})});
+          const r = await fetch(`${API_BASE}/blocks`, {method:'POST', credentials:'include', headers:{'Content-Type':'application/json'}, body:JSON.stringify({blockedUserId: userId})});
           if(r.ok){ _blockedUserIds.add(userId); showToast(`บล็อก ${displayName} แล้ว`); }
         }
         const btn = document.getElementById('blockUserBtn_' + userId) || document.getElementById('blockUserBtn_' + displayName);
@@ -7453,7 +7638,7 @@ function renderFeed(){
     async function deleteAccount(){
       if(!confirm('คุณต้องการลบบัญชีนี้ถาวรหรือไม่?\nข้อมูลส่วนตัวจะถูกลบและไม่สามารถกู้คืนได้')) return;
       try {
-        const r = await fetch('/api/auth/account', {method:'DELETE', credentials:'include'});
+        const r = await fetch(`${API_BASE}/auth/account`, {method:'DELETE', credentials:'include'});
         if(!r.ok){ const d=await r.json(); showToast(d.message||'ลบบัญชีไม่สำเร็จ'); return; }
         showToast('ลบบัญชีเรียบร้อย');
         setTimeout(() => { window.location.href = '/'; }, 1500);
@@ -7484,7 +7669,7 @@ function renderFeed(){
       if(!offerId){ msgEl.textContent='ไม่พบ ID ข้อเสนอ'; msgEl.style.display='block'; return; }
       if(cash === 0 && credit === 0){ msgEl.textContent='กรอกจำนวนเงินสดหรือเครดิต'; msgEl.style.display='block'; return; }
       try {
-        const r = await fetch(`/api/offers/${offerId}/counter`, {
+        const r = await fetch(`${API_BASE}/offers/${offerId}/counter`, {
           method:'POST', credentials:'include',
           headers:{'Content-Type':'application/json'},
           body: JSON.stringify({
@@ -7527,7 +7712,7 @@ function renderFeed(){
           if(_dlIdx >= 0){
             openDetailByIndex(_dlIdx);
           } else {
-            fetch('/api/items/' + encodeURIComponent(_deepLinkItem))
+            fetch(`${API_BASE}/items/` + encodeURIComponent(_deepLinkItem))
               .then(r => r.ok ? r.json() : null)
               .then(data => {
                 if(data?.item){


### PR DESCRIPTION
## Summary\n- 25 calls ใช้ `fetch('/api/...')` hardcoded แทน `${API_BASE}` — บน github.io ทั้งหมดชน Pages static server → 404/405\n- แก้ทุก call ให้ใช้ `` fetch(`${API_BASE}/...`) `` ทำให้ route ถูกต้องทุก environment\n- Root `index.html` synced ให้ตรงกับ `artifacts/web-app/index.html` (รวม update จาก PR #56 ด้วย)\n\n## Affected features (ที่เคย broken บน production)\n- Wallet / Transactions\n- Upload รูปภาพ\n- Bookmarks\n- Chat messages\n- Follows / Blocks\n- Auth: verify-email, forgot-password, reset-password, delete-account\n- Notification settings\n- Disputes\n- Items deep-link\n\nhttps://claude.ai/code/session_01WiC7GF1y7EcNzFWkfHDxW4