### PR TITLE
fix: remove duplicate router declaration in offer_chats.ts (#58)

### DIFF
--- a/artifacts/api-server/src/routes/offer_chats.ts
+++ b/artifacts/api-server/src/routes/offer_chats.ts
@@ -1,11 +1,9 @@
-import { Router, type Request, type Response } from "express";
+import { Router, type IRouter, type Request, type Response } from "express";
 import { z } from "zod/v4";
 import { requireAuth } from "../middlewares/authMiddleware";
 import { sendValidationError, handleError } from "../lib/http";
 import * as OfferChatService from "../services/offer_chat.service";
 import { broadcastToUser } from "../lib/sse";
-
-const router = Router();
 
 const router: IRouter = Router();
 


### PR DESCRIPTION
## Summary\nแก้ `offer_chats.ts` มี `const router` ซ้อนกัน 2 บรรทัด → TypeScript TS2451 redeclaration error → CI fail\n\nเหลือแค่ `const router: IRouter = Router()` บรรทัดเดียว\n\nhttps://claude.ai/code/session_01WiC7GF1y7EcNzFWkfHDxW4

---
_Generated by [Claude Code](https://claude.ai/code/session_01WiC7GF1y7EcNzFWkfHDxW4)_