### PR TITLE
Support configurable frontend API base URL to avoid 404s

### DIFF
--- a/artifacts/web-app/src/api.js
+++ b/artifacts/web-app/src/api.js
@@ -1,4 +1,9 @@
-const BASE = "/api";
+const rawApiBase =
+  (typeof window !== "undefined" && window.__API_BASE__) ||
+  import.meta.env?.VITE_API_BASE ||
+  "/api";
+
+const BASE = String(rawApiBase).replace(/\/$/, "");
 
 async function request(method, path, body) {
   const res = await fetch(BASE + path, {


### PR DESCRIPTION
### Motivation
- Prevent frontend requests from hitting the wrong origin (causing 404s) when the backend is hosted on a different domain by making the API base URL configurable.

### Description
- Change `artifacts/web-app/src/api.js` to resolve the API base from `window.__API_BASE__` then `import.meta.env.VITE_API_BASE` before falling back to `"/api"`.
- Normalize the base by stripping a trailing slash with `String(rawApiBase).replace(/\/$/, "")` to avoid accidental `//` in request paths.
- Preserve existing API call functions (`items.create`, `api.get`, etc.) so no call site changes are required.

### Testing
- Running `pnpm --filter @workspace/web-app run build` without required env vars failed with the expected config error about `PORT`/`BASE_PATH`.
- Running `PORT=4173 BASE_PATH=/ pnpm --filter @workspace/web-app run build` succeeded and produced the built output including `dist/public/index.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4b251df08322958e628de1b3d7e5)