### PR TITLE
Enable session table auto-creation, add image upload flow, remove feed mock fallback

### DIFF
--- a/artifacts/api-server/src/app.ts
+++ b/artifacts/api-server/src/app.ts
@@ -60,7 +60,7 @@ app.use(
     store: new PgStore({
       pool,
       tableName: "user_sessions",
-      createTableIfMissing: false,
+      createTableIfMissing: true,
     }),
     secret: process.env.SESSION_SECRET,
     resave: false,

--- a/artifacts/web-app/src/api.js
+++ b/artifacts/web-app/src/api.js
@@ -25,6 +25,25 @@ async function request(method, path, body) {
   return data;
 }
 
+async function uploadRequest(path, formData) {
+  const res = await fetch(BASE + path, {
+    method: "POST",
+    credentials: "include",
+    body: formData,
+  });
+  let data = null;
+  try {
+    data = await res.json();
+  } catch {
+    data = null;
+  }
+  if (!res.ok) {
+    const msg = data?.error || `HTTP ${res.status}`;
+    throw new Error(msg);
+  }
+  return data;
+}
+
 export const api = {
   get: (p) => request("GET", p),
   post: (p, body) => request("POST", p, body),
@@ -109,4 +128,14 @@ export const chat = {
   conversations: () => api.get("/chat/conversations"),
   messages: (convId) => api.get(`/chat/conversations/${convId}/messages`),
   send: (convId, text) => api.post(`/chat/conversations/${convId}/messages`, { text }),
+};
+
+export const uploads = {
+  images: async (files) => {
+    const list = Array.from(files || []).filter(Boolean);
+    if (!list.length) return { urls: [] };
+    const form = new FormData();
+    list.slice(0, 4).forEach((file) => form.append("images", file));
+    return uploadRequest("/upload", form);
+  },
 };

--- a/artifacts/web-app/src/ui/add.js
+++ b/artifacts/web-app/src/ui/add.js
@@ -1,5 +1,5 @@
 import { qs, notify, debugStatus } from "../util.js";
-import { items } from "../api.js";
+import { items, uploads } from "../api.js";
 import { authGuard } from "./nav.js";
 import { loadShop } from "./shop.js";
 import { loadFeed } from "./feed.js";
@@ -36,14 +36,29 @@ export async function createItem() {
     locationLabel: qs("itemLocation").value.trim() || "Bangkok",
     imageEmoji: qs("itemEmoji").value.trim() || "📦",
   };
+  const imageInput = document.getElementById("itemImages");
+  const imageFiles =
+    imageInput instanceof HTMLInputElement && imageInput.files
+      ? Array.from(imageInput.files)
+      : [];
   if (!payload.title) return notify("addNotice", "error", "กรอกชื่อสินค้าก่อน");
   if (!payload.category)
     return notify("addNotice", "error", "เลือกหมวดหมู่ก่อน");
   if (payload.priceCash < 0 || payload.priceCredit < 0)
     return notify("addNotice", "error", "ราคาติดลบไม่ได้");
   try {
+    if (imageFiles.length) {
+      notify("addNotice", "ok", "กำลังอัปโหลดรูป...");
+      const { urls } = await uploads.images(imageFiles);
+      if (Array.isArray(urls) && urls.length) {
+        payload.imageUrls = urls;
+      }
+    }
     await items.create(payload);
     resetListingForm();
+    if (imageInput instanceof HTMLInputElement) {
+      imageInput.value = "";
+    }
     notify("addNotice", "ok", "เพิ่มสินค้าสำเร็จ");
     loadShop();
     loadFeed();

--- a/artifacts/web-app/src/ui/feed.js
+++ b/artifacts/web-app/src/ui/feed.js
@@ -6,59 +6,6 @@ import { feedCardHtml, bindCardActions, loadSavedListings } from "./cards.js";
 
 export { feedCardHtml };
 
-const FALLBACK_FEED_ITEMS = [
-  {
-    id: "fallback-phone-1",
-    ownerId: "seed-owner-1",
-    title: "iPhone 14 Pro Max 256GB",
-    category: "phone",
-    locationLabel: "Bangkok",
-    dealType: "both",
-    priceCash: 28900,
-    wantedText: "MacBook Air M1 หรือ iPad Pro พร้อม Apple Pencil",
-    requestSummary: "เปิดรับข้อเสนอของใกล้เคียง",
-    conditionLabel: "สภาพดี",
-    imageEmoji: "📱",
-    requestCount: 12,
-    requestPreview: [
-      { name: "Mint", avatar: "" },
-      { name: "Tee", avatar: "" },
-      { name: "Ploy", avatar: "" },
-    ],
-  },
-  {
-    id: "fallback-laptop-2",
-    ownerId: "seed-owner-2",
-    title: "MacBook Pro 14” M2 พร้อมกล่อง",
-    category: "electronics",
-    locationLabel: "ลาดพร้าว",
-    dealType: "swap",
-    priceCash: 0,
-    priceCredit: 0,
-    wantedText: "Sony A6400 + เลนส์ หรือเครดิตมูลค่าใกล้เคียง",
-    requestSummary: "อยากได้กล้อง mirrorless",
-    conditionLabel: "สภาพดีมาก",
-    imageEmoji: "💻",
-    requestCount: 8,
-    requestPreview: [{ name: "Aom" }, { name: "Beam" }],
-  },
-  {
-    id: "fallback-fashion-3",
-    ownerId: "seed-owner-3",
-    title: "Nike Dunk Low Panda ไซซ์ 42",
-    category: "fashion",
-    locationLabel: "ใกล้ฉัน",
-    dealType: "both",
-    priceCash: 3900,
-    wantedText: "Stussy Jacket สีดำ ไซซ์ M",
-    requestSummary: "พร้อมแลกเสื้อผ้าสตรีทแวร์",
-    conditionLabel: "95%",
-    imageEmoji: "👟",
-    requestCount: 3,
-    requestPreview: [{ name: "Ken" }],
-  },
-];
-
 export function setFeedFilter(filter, btn) {
   state.feedFilter = filter;
   document
@@ -104,13 +51,12 @@ function emptyFeedStateHtml() {
   `;
 }
 
-function fallbackFeedStateHtml(list) {
+function feedErrorStateHtml(message) {
   return `
-    <div class="empty feed-fallback-state">
-      <div class="feed-empty-title">ยังไม่มีข้อมูลจากฐานข้อมูลในตอนนี้</div>
-      <div class="feed-empty-sub">แสดงการ์ดตัวอย่างเพื่อให้ฟีดไม่ว่างเปล่า</div>
+    <div class="empty feed-empty-state">
+      <div class="feed-empty-title">โหลดรายการไม่สำเร็จ</div>
+      <div class="feed-empty-sub">${message}</div>
     </div>
-    ${list.map(feedCardHtml).join("")}
   `;
 }
 
@@ -220,8 +166,8 @@ export async function loadFeed() {
     }
     bindCardActions(feed);
   } catch (e) {
-    notify("feedNotice", "error", String(e?.message || e));
-    feed.innerHTML = fallbackFeedStateHtml(FALLBACK_FEED_ITEMS);
-    bindCardActions(feed);
+    const message = String(e?.message || e);
+    notify("feedNotice", "error", message);
+    feed.innerHTML = feedErrorStateHtml(message);
   }
 }


### PR DESCRIPTION
### Motivation

- Ensure sign-in/session works on fresh databases by letting the session store create its table automatically.
- Replace seeded UI mock data with real API behavior so failures surface real errors instead of showing fake cards.
- Add support for multipart image upload in the web client and wire it into the add-listing flow to persist real images.

### Description

- Set `createTableIfMissing: true` for `connect-pg-simple` session store in `artifacts/api-server/src/app.ts` so the `user_sessions` table is bootstrapped when missing.
- Add an `uploadRequest` helper and `uploads.images` client API in `artifacts/web-app/src/api.js` to perform multipart `/upload` requests.
- Update `artifacts/web-app/src/ui/add.js` to read files from an `#itemImages` input, upload them via `uploads.images`, and include returned `imageUrls` in the `items.create` payload.
- Remove the `FALLBACK_FEED_ITEMS` mock cards and show a clear error state on feed load failures in `artifacts/web-app/src/ui/feed.js`.

### Testing

- Ran web-app typecheck with `pnpm --filter @workspace/web-app run typecheck`, which succeeded.
- Executed API server unit tests with `pnpm --filter @workspace/api-server test -- --run src/__tests__/auth.test.ts`, which passed.
- A full workspace typecheck (`pnpm -r --filter ./artifacts/web-app --filter ./artifacts/api-server --if-present run typecheck`) still reports unrelated TypeScript errors in multiple `artifacts/api-server` files (existing TS6305/TS7006), so some type issues outside this change remain unresolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4e4657a4832283199fd3b7c89354)