### PR TITLE
Refactor DB startup migrations, modularize frontend API, add uploads and UI fixes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,42 @@
+# QXwap Architecture Map
+
+This document is the "where to edit what" map to reduce confusion and avoid editing dead/legacy paths.
+
+## 1) Runtime services
+
+### API server
+- Entry: `artifacts/api-server/src/index.ts`
+- Express app wiring: `artifacts/api-server/src/app.ts`
+- Routes: `artifacts/api-server/src/routes/*`
+- Startup DB bootstrap:
+  - Optional baseline SQL file loader: `artifacts/api-server/src/lib/bootstrapSchema.ts`
+  - Incremental startup migrations:
+    - Runner: `artifacts/api-server/src/lib/startup-migrations/index.ts`
+    - Domain step sets: `artifacts/api-server/src/lib/startup-migrations/steps-*.ts`
+
+### Web app
+- Active deploy artifact source: `artifacts/web-app/index.html`
+- Build config: `artifacts/web-app/vite.config.ts`
+- API helpers used by modular code:
+  - Transport/core: `artifacts/web-app/src/api/core.js`
+  - Domain clients:
+    - Aggregator: `artifacts/web-app/src/api.js`
+    - Per-domain modules: `artifacts/web-app/src/api/domains/*.js`
+
+## 2) Data contracts and schema
+- DB schema source package: `lib/db/src/schema/*`
+- API spec and generated clients:
+  - `lib/api-spec/openapi.yaml`
+  - `lib/api-zod/src/generated/*`
+  - `lib/api-client-react/src/generated/*`
+
+## 3) Known mixed-path area
+- `artifacts/web-app/src/ui/*` contains partially modularized UI logic from earlier iterations.
+- `artifacts/web-app/index.html` is still used as primary runtime in current build.
+- Rule: before implementing features, decide one path and keep changes in that path only.
+
+## 4) Recommended refactor sequence (next phase)
+1. Choose single frontend path (single-file or modular).
+2. Remove unused path after parity verification.
+3. Keep API integration centralized through one helper module.
+4. Add smoke tests per critical user journey (auth, listing, upload, feed, offer).

--- a/artifacts/api-server/src/app.ts
+++ b/artifacts/api-server/src/app.ts
@@ -60,7 +60,7 @@ app.use(
     store: new PgStore({
       pool,
       tableName: "user_sessions",
-      createTableIfMissing: false,
+      createTableIfMissing: true,
     }),
     secret: process.env.SESSION_SECRET,
     resave: false,

--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -1,106 +1,14 @@
 import app from "./app";
 import { logger } from "./lib/logger";
 import { pool } from "@workspace/db";
+import { applyBootstrapSchema } from "./lib/bootstrapSchema";
+import { runStartupMigrations } from "./lib/startup-migrations";
 
 async function runMigrations() {
   const client = await pool.connect();
   try {
-    await client.query(
-      `ALTER TABLE items ADD COLUMN IF NOT EXISTS image_urls text[] NOT NULL DEFAULT '{}'`,
-    );
-    await client.query(
-      `ALTER TABLE users ADD COLUMN IF NOT EXISTS email_verified boolean NOT NULL DEFAULT false`,
-    );
-    await client.query(`
-      CREATE TABLE IF NOT EXISTS auth_otps (
-        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
-        user_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-        purpose varchar NOT NULL,
-        code_hash varchar NOT NULL,
-        expires_at timestamptz NOT NULL,
-        used_at timestamptz
-      )
-    `);
-    await client.query(`
-      CREATE TABLE IF NOT EXISTS disputes (
-        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
-        reporter_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-        reported_user_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-        deal_id varchar REFERENCES deals(id) ON DELETE SET NULL,
-        reason varchar NOT NULL,
-        detail text,
-        status varchar NOT NULL DEFAULT 'open',
-        created_at timestamptz NOT NULL DEFAULT now()
-      )
-    `);
-    // Full-text search vector on items
-    await client.query(
-      `ALTER TABLE items ADD COLUMN IF NOT EXISTS search_vector tsvector`,
-    );
-    await client.query(`
-      CREATE INDEX IF NOT EXISTS idx_items_search ON items USING GIN(search_vector)
-    `);
-    await client.query(`
-      CREATE OR REPLACE FUNCTION items_search_vector_update() RETURNS trigger LANGUAGE plpgsql AS $$
-      BEGIN
-        NEW.search_vector :=
-          setweight(to_tsvector('simple', coalesce(NEW.title,'')), 'A') ||
-          setweight(to_tsvector('simple', coalesce(NEW.description,'')), 'B') ||
-          setweight(to_tsvector('simple', coalesce(NEW.wanted_text,'')), 'C') ||
-          setweight(to_tsvector('simple', coalesce(NEW.category,'')), 'D');
-        RETURN NEW;
-      END; $$
-    `);
-    await client.query(`
-      DROP TRIGGER IF EXISTS items_search_vector_trigger ON items
-    `);
-    await client.query(`
-      CREATE TRIGGER items_search_vector_trigger
-      BEFORE INSERT OR UPDATE ON items
-      FOR EACH ROW EXECUTE FUNCTION items_search_vector_update()
-    `);
-    // Back-fill existing rows
-    await client.query(`
-      UPDATE items SET search_vector =
-        setweight(to_tsvector('simple', coalesce(title,'')), 'A') ||
-        setweight(to_tsvector('simple', coalesce(description,'')), 'B') ||
-        setweight(to_tsvector('simple', coalesce(wanted_text,'')), 'C') ||
-        setweight(to_tsvector('simple', coalesce(category,'')), 'D')
-      WHERE search_vector IS NULL
-    `);
-    await client.query(`
-      CREATE TABLE IF NOT EXISTS reviews (
-        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
-        deal_id varchar NOT NULL REFERENCES deals(id) ON DELETE CASCADE,
-        reviewer_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-        reviewee_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-        rating integer NOT NULL CHECK (rating BETWEEN 1 AND 5),
-        comment text,
-        created_at timestamptz NOT NULL DEFAULT now(),
-        UNIQUE(deal_id, reviewer_id)
-      )
-    `);
-    await client.query(`
-      CREATE TABLE IF NOT EXISTS blocks (
-        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
-        blocker_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-        blocked_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-        created_at timestamptz NOT NULL DEFAULT now(),
-        UNIQUE(blocker_id, blocked_id)
-      )
-    `);
-    await client.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS bio text`);
-    await client.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS notification_settings text NOT NULL DEFAULT '{}'`);
-    await client.query(`ALTER TABLE offer_messages ADD COLUMN IF NOT EXISTS image_url text`);
-    await client.query(`
-      CREATE TABLE IF NOT EXISTS follows (
-        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
-        follower_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-        following_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-        created_at timestamptz NOT NULL DEFAULT now(),
-        UNIQUE(follower_id, following_id)
-      )
-    `);
+    await applyBootstrapSchema(client);
+    await runStartupMigrations(client);
   } catch (err) {
     logger.warn({ err }, "migration.warning");
   } finally {

--- a/artifacts/api-server/src/lib/bootstrapSchema.ts
+++ b/artifacts/api-server/src/lib/bootstrapSchema.ts
@@ -1,0 +1,31 @@
+import fs from "fs";
+import path from "path";
+import { logger } from "./logger";
+
+interface SqlClient {
+  query: (sql: string) => Promise<unknown>;
+}
+
+export function findBootstrapSchemaFile(): string | null {
+  const candidates = [
+    path.join(process.cwd(), "qxwap_supabase_schema_policy.sql"),
+    path.join(process.cwd(), "..", "..", "qxwap_supabase_schema_policy.sql"),
+    path.join(process.cwd(), "..", "qxwap_supabase_schema_policy.sql"),
+  ];
+  for (const file of candidates) {
+    if (fs.existsSync(file)) return file;
+  }
+  return null;
+}
+
+export async function applyBootstrapSchema(client: SqlClient): Promise<void> {
+  const bootstrapSchema = findBootstrapSchemaFile();
+  if (!bootstrapSchema) {
+    logger.warn("migration.bootstrap_schema_not_found");
+    return;
+  }
+
+  const sql = fs.readFileSync(bootstrapSchema, "utf8");
+  await client.query(sql);
+  logger.info({ bootstrapSchema }, "migration.bootstrap_schema_applied");
+}

--- a/artifacts/api-server/src/lib/startup-migrations/index.ts
+++ b/artifacts/api-server/src/lib/startup-migrations/index.ts
@@ -1,0 +1,25 @@
+import { logger } from "../logger";
+import { authAndProfileSteps } from "./steps-auth-profile";
+import { coreSteps } from "./steps-core";
+import { listingAndSearchSteps } from "./steps-listing-search";
+import { messagingSteps } from "./steps-messaging";
+import { trustAndSafetySteps } from "./steps-trust-safety";
+import type { SqlClient, SqlStep } from "./types";
+
+export const startupSteps: SqlStep[] = [
+  ...coreSteps,
+  ...authAndProfileSteps,
+  ...listingAndSearchSteps,
+  ...trustAndSafetySteps,
+  ...messagingSteps,
+];
+
+export async function runStartupMigrations(client: SqlClient): Promise<void> {
+  for (const step of startupSteps) {
+    try {
+      await client.query(step.sql);
+    } catch (err) {
+      logger.warn({ err, step: step.name }, "migration.step_failed");
+    }
+  }
+}

--- a/artifacts/api-server/src/lib/startup-migrations/steps-auth-profile.ts
+++ b/artifacts/api-server/src/lib/startup-migrations/steps-auth-profile.ts
@@ -1,0 +1,50 @@
+import type { SqlStep } from "./types";
+
+export const authAndProfileSteps: SqlStep[] = [
+  {
+    name: "alter.users_email_verified",
+    sql: `ALTER TABLE users ADD COLUMN IF NOT EXISTS email_verified boolean NOT NULL DEFAULT false`,
+  },
+  {
+    name: "table.auth_otps",
+    sql: `
+      CREATE TABLE IF NOT EXISTS auth_otps (
+        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        purpose varchar NOT NULL,
+        code_hash varchar NOT NULL,
+        expires_at timestamptz NOT NULL,
+        used_at timestamptz
+      )
+    `,
+  },
+  { name: "alter.profiles_bio", sql: `ALTER TABLE profiles ADD COLUMN IF NOT EXISTS bio text` },
+  {
+    name: "alter.profiles_notification_settings",
+    sql: `ALTER TABLE profiles ADD COLUMN IF NOT EXISTS notification_settings text NOT NULL DEFAULT '{}'`,
+  },
+  {
+    name: "table.follows",
+    sql: `
+      CREATE TABLE IF NOT EXISTS follows (
+        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+        follower_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        following_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        UNIQUE(follower_id, following_id)
+      )
+    `,
+  },
+  {
+    name: "table.blocks",
+    sql: `
+      CREATE TABLE IF NOT EXISTS blocks (
+        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+        blocker_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        blocked_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        UNIQUE(blocker_id, blocked_id)
+      )
+    `,
+  },
+];

--- a/artifacts/api-server/src/lib/startup-migrations/steps-core.ts
+++ b/artifacts/api-server/src/lib/startup-migrations/steps-core.ts
@@ -1,0 +1,54 @@
+import type { SqlStep } from "./types";
+
+export const coreSteps: SqlStep[] = [
+  { name: "extension.pgcrypto", sql: `CREATE EXTENSION IF NOT EXISTS pgcrypto` },
+  {
+    name: "table.users",
+    sql: `
+      CREATE TABLE IF NOT EXISTS users (
+        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+        email varchar UNIQUE,
+        password_hash varchar,
+        replit_user_id varchar UNIQUE,
+        first_name varchar,
+        last_name varchar,
+        profile_image_url varchar,
+        email_verified boolean NOT NULL DEFAULT false,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now()
+      )
+    `,
+  },
+  {
+    name: "table.profiles",
+    sql: `
+      CREATE TABLE IF NOT EXISTS profiles (
+        id varchar PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+        username varchar,
+        display_name varchar,
+        avatar_url varchar,
+        bio text,
+        city varchar NOT NULL DEFAULT 'Bangkok',
+        verified_status boolean NOT NULL DEFAULT false,
+        rating_avg numeric(3, 2) NOT NULL DEFAULT '0',
+        successful_deals_count integer NOT NULL DEFAULT 0,
+        notification_settings text NOT NULL DEFAULT '{}',
+        created_at timestamptz NOT NULL DEFAULT now()
+      )
+    `,
+  },
+  {
+    name: "table.user_sessions",
+    sql: `
+      CREATE TABLE IF NOT EXISTS user_sessions (
+        sid varchar PRIMARY KEY NOT NULL,
+        sess json NOT NULL,
+        expire timestamp(6) NOT NULL
+      )
+    `,
+  },
+  {
+    name: "index.user_sessions_expire",
+    sql: `CREATE INDEX IF NOT EXISTS IDX_user_sessions_expire ON user_sessions (expire)`,
+  },
+];

--- a/artifacts/api-server/src/lib/startup-migrations/steps-listing-search.ts
+++ b/artifacts/api-server/src/lib/startup-migrations/steps-listing-search.ts
@@ -1,0 +1,50 @@
+import type { SqlStep } from "./types";
+
+export const listingAndSearchSteps: SqlStep[] = [
+  {
+    name: "alter.items_image_urls",
+    sql: `ALTER TABLE items ADD COLUMN IF NOT EXISTS image_urls text[] NOT NULL DEFAULT '{}'`,
+  },
+  {
+    name: "alter.items_search_vector",
+    sql: `ALTER TABLE items ADD COLUMN IF NOT EXISTS search_vector tsvector`,
+  },
+  {
+    name: "index.items_search",
+    sql: `CREATE INDEX IF NOT EXISTS idx_items_search ON items USING GIN(search_vector)`,
+  },
+  {
+    name: "fn.items_search_vector_update",
+    sql: `
+      CREATE OR REPLACE FUNCTION items_search_vector_update() RETURNS trigger LANGUAGE plpgsql AS $$
+      BEGIN
+        NEW.search_vector :=
+          setweight(to_tsvector('simple', coalesce(NEW.title,'')), 'A') ||
+          setweight(to_tsvector('simple', coalesce(NEW.description,'')), 'B') ||
+          setweight(to_tsvector('simple', coalesce(NEW.wanted_text,'')), 'C') ||
+          setweight(to_tsvector('simple', coalesce(NEW.category,'')), 'D');
+        RETURN NEW;
+      END; $$
+    `,
+  },
+  { name: "trigger.drop_items_search_vector", sql: `DROP TRIGGER IF EXISTS items_search_vector_trigger ON items` },
+  {
+    name: "trigger.create_items_search_vector",
+    sql: `
+      CREATE TRIGGER items_search_vector_trigger
+      BEFORE INSERT OR UPDATE ON items
+      FOR EACH ROW EXECUTE FUNCTION items_search_vector_update()
+    `,
+  },
+  {
+    name: "backfill.items_search_vector",
+    sql: `
+      UPDATE items SET search_vector =
+        setweight(to_tsvector('simple', coalesce(title,'')), 'A') ||
+        setweight(to_tsvector('simple', coalesce(description,'')), 'B') ||
+        setweight(to_tsvector('simple', coalesce(wanted_text,'')), 'C') ||
+        setweight(to_tsvector('simple', coalesce(category,'')), 'D')
+      WHERE search_vector IS NULL
+    `,
+  },
+];

--- a/artifacts/api-server/src/lib/startup-migrations/steps-messaging.ts
+++ b/artifacts/api-server/src/lib/startup-migrations/steps-messaging.ts
@@ -1,0 +1,8 @@
+import type { SqlStep } from "./types";
+
+export const messagingSteps: SqlStep[] = [
+  {
+    name: "alter.offer_messages_image_url",
+    sql: `ALTER TABLE offer_messages ADD COLUMN IF NOT EXISTS image_url text`,
+  },
+];

--- a/artifacts/api-server/src/lib/startup-migrations/steps-trust-safety.ts
+++ b/artifacts/api-server/src/lib/startup-migrations/steps-trust-safety.ts
@@ -1,0 +1,34 @@
+import type { SqlStep } from "./types";
+
+export const trustAndSafetySteps: SqlStep[] = [
+  {
+    name: "table.disputes",
+    sql: `
+      CREATE TABLE IF NOT EXISTS disputes (
+        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+        reporter_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        reported_user_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        deal_id varchar REFERENCES deals(id) ON DELETE SET NULL,
+        reason varchar NOT NULL,
+        detail text,
+        status varchar NOT NULL DEFAULT 'open',
+        created_at timestamptz NOT NULL DEFAULT now()
+      )
+    `,
+  },
+  {
+    name: "table.reviews",
+    sql: `
+      CREATE TABLE IF NOT EXISTS reviews (
+        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+        deal_id varchar NOT NULL REFERENCES deals(id) ON DELETE CASCADE,
+        reviewer_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        reviewee_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        rating integer NOT NULL CHECK (rating BETWEEN 1 AND 5),
+        comment text,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        UNIQUE(deal_id, reviewer_id)
+      )
+    `,
+  },
+];

--- a/artifacts/api-server/src/lib/startup-migrations/types.ts
+++ b/artifacts/api-server/src/lib/startup-migrations/types.ts
@@ -1,0 +1,8 @@
+export interface SqlClient {
+  query: (sql: string) => Promise<unknown>;
+}
+
+export type SqlStep = {
+  name: string;
+  sql: string;
+};

--- a/artifacts/web-app/ARCHITECTURE.md
+++ b/artifacts/web-app/ARCHITECTURE.md
@@ -1,0 +1,23 @@
+# Web App Structure (Current Source of Truth)
+
+## Runtime app
+- **Primary runtime UI:** `artifacts/web-app/index.html`
+  - This file contains the active UI markup + runtime script that is built/deployed by Vite.
+- **Build config:** `artifacts/web-app/vite.config.ts`
+
+## API integration
+- Frontend API calls are centralized in:
+  - `artifacts/web-app/src/api/core.js` (base URL, request/upload transport, query string helper)
+  - `artifacts/web-app/src/api.js` (domain aggregator)
+  - `artifacts/web-app/src/api/domains/*.js` (feature/domain API groups)
+- If you are working on auth/listing/feed behavior, verify the page path actually uses that module path before editing.
+
+## Important note about legacy/experimental files
+- The `artifacts/web-app/src/ui/*` files are partially modularized logic from earlier iterations.
+- Some deployments still use the single-file runtime in `index.html`.
+- Before changing features, confirm which path is active in your deployed artifact.
+
+## Cleanup direction
+1. Keep feature changes in one path only (single-file or modular), not both.
+2. Avoid introducing mock fallback data in production flows.
+3. Prefer explicit API base configuration (`VITE_API_BASE`) in deploy environments.

--- a/artifacts/web-app/src/api.js
+++ b/artifacts/web-app/src/api.js
@@ -1,29 +1,15 @@
-const rawApiBase =
-  (typeof window !== "undefined" && window.__API_BASE__) ||
-  import.meta.env?.VITE_API_BASE ||
-  "/api";
-
-const BASE = String(rawApiBase).replace(/\/$/, "");
-
-async function request(method, path, body) {
-  const res = await fetch(BASE + path, {
-    method,
-    credentials: "include",
-    headers: body ? { "Content-Type": "application/json" } : {},
-    body: body ? JSON.stringify(body) : undefined,
-  });
-  let data = null;
-  try {
-    data = await res.json();
-  } catch {
-    data = null;
-  }
-  if (!res.ok) {
-    const msg = data?.error || `HTTP ${res.status}`;
-    throw new Error(msg);
-  }
-  return data;
-}
+import { BASE, queryString, request, uploadRequest } from "./api/core.js";
+import { createAuthApi } from "./api/domains/auth.js";
+import { createItemsApi } from "./api/domains/items.js";
+import { createOffersApi } from "./api/domains/offers.js";
+import { createProfilesApi } from "./api/domains/profile.js";
+import { createBookmarksApi } from "./api/domains/bookmarks.js";
+import { createWalletApi } from "./api/domains/wallet.js";
+import { createNotificationsApi } from "./api/domains/notifications.js";
+import { createDealsApi } from "./api/domains/deals.js";
+import { createShipmentsApi } from "./api/domains/shipments.js";
+import { createChatApi } from "./api/domains/chat.js";
+import { createUploadsApi } from "./api/domains/uploads.js";
 
 export const api = {
   get: (p) => request("GET", p),
@@ -32,81 +18,14 @@ export const api = {
   del: (p) => request("DELETE", p),
 };
 
-export const auth = {
-  me: () => api.get("/auth/me"),
-  signup: (email, password) => api.post("/auth/signup", { email, password }),
-  signin: (email, password) => api.post("/auth/signin", { email, password }),
-  signout: () => api.post("/auth/signout", {}),
-  replitLoginUrl: () => `${BASE}/auth/replit/login`,
-};
-
-function qs(params = {}) {
-  const q = new URLSearchParams(
-    Object.entries(params).filter(([, v]) => v !== undefined && v !== ""),
-  ).toString();
-  return q ? "?" + q : "";
-}
-
-export const items = {
-  list: (params = {}) => api.get(`/items${qs(params)}`),
-  feed: () => api.get("/feed"),
-  create: (payload) => api.post("/items", payload),
-  update: (id, payload) => api.patch(`/items/${id}`, payload),
-  remove: (id) => api.del(`/items/${id}`),
-};
-
-export const offers = {
-  list: () => api.get("/offers"),
-  sent: () => api.get("/offers/sent"),
-  received: () => api.get("/offers/received"),
-  get: (id) => api.get(`/offers/${id}`),
-  create: (payload) => api.post("/offers", payload),
-  accept: (id) => api.post(`/offers/${id}/accept`, {}),
-  reject: (id) => api.post(`/offers/${id}/reject`, {}),
-  cancel: (id) => api.post(`/offers/${id}/cancel`, {}),
-  confirm: (id) => api.post(`/offers/${id}/confirm`, {}),
-};
-
-export const profiles = {
-  me: () => api.get("/profiles/me"),
-  get: (id) => api.get(`/profiles/${id}`),
-  update: (payload) => api.patch("/profiles/me", payload),
-};
-
-export const bookmarks = {
-  list: () => api.get("/bookmarks"),
-  save: (itemId) => api.post("/bookmarks", { itemId }),
-  unsave: (itemId) =>
-    api.del(`/bookmarks/${encodeURIComponent(String(itemId || ""))}`),
-};
-
-export const wallet = {
-  get: () => api.get("/wallet"),
-  transactions: (params = {}) => api.get(`/transactions${qs(params)}`),
-  deposit: (amount) => api.post("/wallet/deposit", { amount }),
-};
-
-export const notifications = {
-  list: () => api.get("/notifications"),
-  markRead: (ids) => api.post("/notifications/read", ids ? { ids } : {}),
-};
-
-export const deals = {
-  mine: () => api.get("/deals/mine"),
-  get: (id) => api.get(`/deals/${id}`),
-  updateStage: (id, stage) => api.patch(`/deals/${id}/stage`, { stage }),
-  updateLogistics: (id, payload) => api.patch(`/deals/${id}/logistics`, payload),
-};
-
-export const shipments = {
-  start: (offerId) => api.post(`/shipments/${offerId}/start`, {}),
-  updateStep: (id, step) => api.post(`/shipments/${id}/update-step`, { step }),
-  finish: (id) => api.post(`/shipments/${id}/finish`, {}),
-  get: (offerId) => api.get(`/shipments/${offerId}`),
-};
-
-export const chat = {
-  conversations: () => api.get("/chat/conversations"),
-  messages: (convId) => api.get(`/chat/conversations/${convId}/messages`),
-  send: (convId, text) => api.post(`/chat/conversations/${convId}/messages`, { text }),
-};
+export const auth = createAuthApi(api, BASE);
+export const items = createItemsApi(api, queryString);
+export const offers = createOffersApi(api);
+export const profiles = createProfilesApi(api);
+export const bookmarks = createBookmarksApi(api);
+export const wallet = createWalletApi(api, queryString);
+export const notifications = createNotificationsApi(api);
+export const deals = createDealsApi(api);
+export const shipments = createShipmentsApi(api);
+export const chat = createChatApi(api);
+export const uploads = createUploadsApi(uploadRequest);

--- a/artifacts/web-app/src/api/core.js
+++ b/artifacts/web-app/src/api/core.js
@@ -1,0 +1,44 @@
+const rawApiBase =
+  (typeof window !== "undefined" && window.__API_BASE__) ||
+  import.meta.env?.VITE_API_BASE ||
+  "/api";
+
+export const BASE = String(rawApiBase).replace(/\/$/, "");
+
+function parseJsonSafe(res) {
+  return res.json().catch(() => null);
+}
+
+function toErrorMessage(data, status) {
+  return data?.error || `HTTP ${status}`;
+}
+
+export async function request(method, path, body) {
+  const res = await fetch(BASE + path, {
+    method,
+    credentials: "include",
+    headers: body ? { "Content-Type": "application/json" } : {},
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await parseJsonSafe(res);
+  if (!res.ok) throw new Error(toErrorMessage(data, res.status));
+  return data;
+}
+
+export async function uploadRequest(path, formData) {
+  const res = await fetch(BASE + path, {
+    method: "POST",
+    credentials: "include",
+    body: formData,
+  });
+  const data = await parseJsonSafe(res);
+  if (!res.ok) throw new Error(toErrorMessage(data, res.status));
+  return data;
+}
+
+export function queryString(params = {}) {
+  const q = new URLSearchParams(
+    Object.entries(params).filter(([, v]) => v !== undefined && v !== ""),
+  ).toString();
+  return q ? "?" + q : "";
+}

--- a/artifacts/web-app/src/api/domains/auth.js
+++ b/artifacts/web-app/src/api/domains/auth.js
@@ -1,0 +1,9 @@
+export function createAuthApi(api, base) {
+  return {
+    me: () => api.get("/auth/me"),
+    signup: (email, password) => api.post("/auth/signup", { email, password }),
+    signin: (email, password) => api.post("/auth/signin", { email, password }),
+    signout: () => api.post("/auth/signout", {}),
+    replitLoginUrl: () => `${base}/auth/replit/login`,
+  };
+}

--- a/artifacts/web-app/src/api/domains/bookmarks.js
+++ b/artifacts/web-app/src/api/domains/bookmarks.js
@@ -1,0 +1,8 @@
+export function createBookmarksApi(api) {
+  return {
+    list: () => api.get("/bookmarks"),
+    save: (itemId) => api.post("/bookmarks", { itemId }),
+    unsave: (itemId) =>
+      api.del(`/bookmarks/${encodeURIComponent(String(itemId || ""))}`),
+  };
+}

--- a/artifacts/web-app/src/api/domains/chat.js
+++ b/artifacts/web-app/src/api/domains/chat.js
@@ -1,0 +1,7 @@
+export function createChatApi(api) {
+  return {
+    conversations: () => api.get("/chat/conversations"),
+    messages: (convId) => api.get(`/chat/conversations/${convId}/messages`),
+    send: (convId, text) => api.post(`/chat/conversations/${convId}/messages`, { text }),
+  };
+}

--- a/artifacts/web-app/src/api/domains/deals.js
+++ b/artifacts/web-app/src/api/domains/deals.js
@@ -1,0 +1,8 @@
+export function createDealsApi(api) {
+  return {
+    mine: () => api.get("/deals/mine"),
+    get: (id) => api.get(`/deals/${id}`),
+    updateStage: (id, stage) => api.patch(`/deals/${id}/stage`, { stage }),
+    updateLogistics: (id, payload) => api.patch(`/deals/${id}/logistics`, payload),
+  };
+}

--- a/artifacts/web-app/src/api/domains/items.js
+++ b/artifacts/web-app/src/api/domains/items.js
@@ -1,0 +1,9 @@
+export function createItemsApi(api, queryString) {
+  return {
+    list: (params = {}) => api.get(`/items${queryString(params)}`),
+    feed: () => api.get("/feed"),
+    create: (payload) => api.post("/items", payload),
+    update: (id, payload) => api.patch(`/items/${id}`, payload),
+    remove: (id) => api.del(`/items/${id}`),
+  };
+}

--- a/artifacts/web-app/src/api/domains/notifications.js
+++ b/artifacts/web-app/src/api/domains/notifications.js
@@ -1,0 +1,6 @@
+export function createNotificationsApi(api) {
+  return {
+    list: () => api.get("/notifications"),
+    markRead: (ids) => api.post("/notifications/read", ids ? { ids } : {}),
+  };
+}

--- a/artifacts/web-app/src/api/domains/offers.js
+++ b/artifacts/web-app/src/api/domains/offers.js
@@ -1,0 +1,13 @@
+export function createOffersApi(api) {
+  return {
+    list: () => api.get("/offers"),
+    sent: () => api.get("/offers/sent"),
+    received: () => api.get("/offers/received"),
+    get: (id) => api.get(`/offers/${id}`),
+    create: (payload) => api.post("/offers", payload),
+    accept: (id) => api.post(`/offers/${id}/accept`, {}),
+    reject: (id) => api.post(`/offers/${id}/reject`, {}),
+    cancel: (id) => api.post(`/offers/${id}/cancel`, {}),
+    confirm: (id) => api.post(`/offers/${id}/confirm`, {}),
+  };
+}

--- a/artifacts/web-app/src/api/domains/profile.js
+++ b/artifacts/web-app/src/api/domains/profile.js
@@ -1,0 +1,7 @@
+export function createProfilesApi(api) {
+  return {
+    me: () => api.get("/profiles/me"),
+    get: (id) => api.get(`/profiles/${id}`),
+    update: (payload) => api.patch("/profiles/me", payload),
+  };
+}

--- a/artifacts/web-app/src/api/domains/shipments.js
+++ b/artifacts/web-app/src/api/domains/shipments.js
@@ -1,0 +1,8 @@
+export function createShipmentsApi(api) {
+  return {
+    start: (offerId) => api.post(`/shipments/${offerId}/start`, {}),
+    updateStep: (id, step) => api.post(`/shipments/${id}/update-step`, { step }),
+    finish: (id) => api.post(`/shipments/${id}/finish`, {}),
+    get: (offerId) => api.get(`/shipments/${offerId}`),
+  };
+}

--- a/artifacts/web-app/src/api/domains/uploads.js
+++ b/artifacts/web-app/src/api/domains/uploads.js
@@ -1,0 +1,11 @@
+export function createUploadsApi(uploadRequest) {
+  return {
+    images: async (files) => {
+      const list = Array.from(files || []).filter(Boolean);
+      if (!list.length) return { urls: [] };
+      const form = new FormData();
+      list.slice(0, 4).forEach((file) => form.append("images", file));
+      return uploadRequest("/upload", form);
+    },
+  };
+}

--- a/artifacts/web-app/src/api/domains/wallet.js
+++ b/artifacts/web-app/src/api/domains/wallet.js
@@ -1,0 +1,7 @@
+export function createWalletApi(api, queryString) {
+  return {
+    get: () => api.get("/wallet"),
+    transactions: (params = {}) => api.get(`/transactions${queryString(params)}`),
+    deposit: (amount) => api.post("/wallet/deposit", { amount }),
+  };
+}

--- a/artifacts/web-app/src/ui/add.js
+++ b/artifacts/web-app/src/ui/add.js
@@ -1,5 +1,5 @@
 import { qs, notify, debugStatus } from "../util.js";
-import { items } from "../api.js";
+import { items, uploads } from "../api.js";
 import { authGuard } from "./nav.js";
 import { loadShop } from "./shop.js";
 import { loadFeed } from "./feed.js";
@@ -36,14 +36,29 @@ export async function createItem() {
     locationLabel: qs("itemLocation").value.trim() || "Bangkok",
     imageEmoji: qs("itemEmoji").value.trim() || "📦",
   };
+  const imageInput = document.getElementById("itemImages");
+  const imageFiles =
+    imageInput instanceof HTMLInputElement && imageInput.files
+      ? Array.from(imageInput.files)
+      : [];
   if (!payload.title) return notify("addNotice", "error", "กรอกชื่อสินค้าก่อน");
   if (!payload.category)
     return notify("addNotice", "error", "เลือกหมวดหมู่ก่อน");
   if (payload.priceCash < 0 || payload.priceCredit < 0)
     return notify("addNotice", "error", "ราคาติดลบไม่ได้");
   try {
+    if (imageFiles.length) {
+      notify("addNotice", "ok", "กำลังอัปโหลดรูป...");
+      const { urls } = await uploads.images(imageFiles);
+      if (Array.isArray(urls) && urls.length) {
+        payload.imageUrls = urls;
+      }
+    }
     await items.create(payload);
     resetListingForm();
+    if (imageInput instanceof HTMLInputElement) {
+      imageInput.value = "";
+    }
     notify("addNotice", "ok", "เพิ่มสินค้าสำเร็จ");
     loadShop();
     loadFeed();

--- a/artifacts/web-app/src/ui/feed.js
+++ b/artifacts/web-app/src/ui/feed.js
@@ -6,59 +6,6 @@ import { feedCardHtml, bindCardActions, loadSavedListings } from "./cards.js";
 
 export { feedCardHtml };
 
-const FALLBACK_FEED_ITEMS = [
-  {
-    id: "fallback-phone-1",
-    ownerId: "seed-owner-1",
-    title: "iPhone 14 Pro Max 256GB",
-    category: "phone",
-    locationLabel: "Bangkok",
-    dealType: "both",
-    priceCash: 28900,
-    wantedText: "MacBook Air M1 หรือ iPad Pro พร้อม Apple Pencil",
-    requestSummary: "เปิดรับข้อเสนอของใกล้เคียง",
-    conditionLabel: "สภาพดี",
-    imageEmoji: "📱",
-    requestCount: 12,
-    requestPreview: [
-      { name: "Mint", avatar: "" },
-      { name: "Tee", avatar: "" },
-      { name: "Ploy", avatar: "" },
-    ],
-  },
-  {
-    id: "fallback-laptop-2",
-    ownerId: "seed-owner-2",
-    title: "MacBook Pro 14” M2 พร้อมกล่อง",
-    category: "electronics",
-    locationLabel: "ลาดพร้าว",
-    dealType: "swap",
-    priceCash: 0,
-    priceCredit: 0,
-    wantedText: "Sony A6400 + เลนส์ หรือเครดิตมูลค่าใกล้เคียง",
-    requestSummary: "อยากได้กล้อง mirrorless",
-    conditionLabel: "สภาพดีมาก",
-    imageEmoji: "💻",
-    requestCount: 8,
-    requestPreview: [{ name: "Aom" }, { name: "Beam" }],
-  },
-  {
-    id: "fallback-fashion-3",
-    ownerId: "seed-owner-3",
-    title: "Nike Dunk Low Panda ไซซ์ 42",
-    category: "fashion",
-    locationLabel: "ใกล้ฉัน",
-    dealType: "both",
-    priceCash: 3900,
-    wantedText: "Stussy Jacket สีดำ ไซซ์ M",
-    requestSummary: "พร้อมแลกเสื้อผ้าสตรีทแวร์",
-    conditionLabel: "95%",
-    imageEmoji: "👟",
-    requestCount: 3,
-    requestPreview: [{ name: "Ken" }],
-  },
-];
-
 export function setFeedFilter(filter, btn) {
   state.feedFilter = filter;
   document
@@ -104,13 +51,12 @@ function emptyFeedStateHtml() {
   `;
 }
 
-function fallbackFeedStateHtml(list) {
+function feedErrorStateHtml(message) {
   return `
-    <div class="empty feed-fallback-state">
-      <div class="feed-empty-title">ยังไม่มีข้อมูลจากฐานข้อมูลในตอนนี้</div>
-      <div class="feed-empty-sub">แสดงการ์ดตัวอย่างเพื่อให้ฟีดไม่ว่างเปล่า</div>
+    <div class="empty feed-empty-state">
+      <div class="feed-empty-title">โหลดรายการไม่สำเร็จ</div>
+      <div class="feed-empty-sub">${message}</div>
     </div>
-    ${list.map(feedCardHtml).join("")}
   `;
 }
 
@@ -220,8 +166,8 @@ export async function loadFeed() {
     }
     bindCardActions(feed);
   } catch (e) {
-    notify("feedNotice", "error", String(e?.message || e));
-    feed.innerHTML = fallbackFeedStateHtml(FALLBACK_FEED_ITEMS);
-    bindCardActions(feed);
+    const message = String(e?.message || e);
+    notify("feedNotice", "error", message);
+    feed.innerHTML = feedErrorStateHtml(message);
   }
 }

--- a/artifacts/web-app/vite.config.ts
+++ b/artifacts/web-app/vite.config.ts
@@ -1,6 +1,4 @@
 import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
-import tailwindcss from "@tailwindcss/vite";
 import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
@@ -29,8 +27,6 @@ if (!basePath) {
 export default defineConfig({
   base: basePath,
   plugins: [
-    react(),
-    tailwindcss(),
     runtimeErrorOverlay(),
     ...(process.env.NODE_ENV !== "production" &&
     process.env.REPL_ID !== undefined
@@ -48,10 +44,8 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(import.meta.dirname, "src"),
       "@assets": path.resolve(import.meta.dirname, "..", "..", "attached_assets"),
     },
-    dedupe: ["react", "react-dom"],
   },
   root: path.resolve(import.meta.dirname),
   build: {


### PR DESCRIPTION
### Motivation

- Move inline startup SQL into structured/bootstrapable steps to make migrations maintainable and discoverable.
- Centralize frontend API logic and split domain clients to remove duplicated request logic and enable reuse of upload transport.
- Add image upload support for listing creation and improve feed error handling and UX when the backend fails.
- Provide architecture guidance documents to reduce confusion about source-of-truth paths for API server and web app.

### Description

- Reworked server startup: added `artifacts/api-server/src/lib/bootstrapSchema.ts` and a `startup-migrations` subsystem (`index.ts`, `types.ts`, and per-area `steps-*.ts`) and replaced the inline SQL in `artifacts/api-server/src/index.ts` with calls to `applyBootstrapSchema` and `runStartupMigrations`.
- Changed session store behavior in `artifacts/api-server/src/app.ts` to set `createTableIfMissing: true` for `user_sessions` and kept existing session configuration.
- Modularized the web client API surface by introducing `artifacts/web-app/src/api/core.js` (request/upload helpers and `queryString`) and domain factories under `artifacts/web-app/src/api/domains/*`, and updated `artifacts/web-app/src/api.js` to compose those factories (`auth`, `items`, `offers`, `profiles`, `bookmarks`, `wallet`, `notifications`, `deals`, `shipments`, `chat`, `uploads`).
- Added upload handling and UI changes: `artifacts/web-app/src/api/domains/uploads.js` implements `images`, `artifacts/web-app/src/ui/add.js` now uploads images before creating an item and clears the input, and `artifacts/web-app/src/ui/feed.js` removes fallback seed data and shows an error state message on failure.
- Added `ARCHITECTURE.md` files for project-wide and web-app-specific guidance, and simplified `artifacts/web-app/vite.config.ts` by removing unused plugins and cleaning up aliases.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4e4657a4832283199fd3b7c89354)