### PR TITLE
Add `preflight:pr` script to check merge conflicts and run backend/frontend checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "preinstall": "sh -c 'rm -f package-lock.json yarn.lock; case \"$npm_config_user_agent\" in pnpm/*) ;; *) echo \"Use pnpm instead\" >&2; exit 1 ;; esac'",
     "build": "pnpm run typecheck && pnpm -r --if-present run build",
+    "preflight:pr": "bash ./scripts/preflight-pr.sh",
     "typecheck:libs": "tsc --build",
     "typecheck": "pnpm run typecheck:libs && pnpm -r --filter \"./artifacts/**\" --filter \"./scripts\" --if-present run typecheck"
   },

--- a/scripts/preflight-pr.sh
+++ b/scripts/preflight-pr.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_BRANCH="${1:-origin/main}"
+
+echo "[1/4] Fetching target branch: ${TARGET_BRANCH}"
+git fetch origin "${TARGET_BRANCH#origin/}" --depth=200
+
+BASE_COMMIT="$(git merge-base HEAD "${TARGET_BRANCH}")"
+echo "merge-base: ${BASE_COMMIT}"
+
+echo "[2/4] Checking merge conflicts (without modifying branch)"
+if git merge-tree "${BASE_COMMIT}" HEAD "${TARGET_BRANCH}" | grep -q "^<<<<<<< "; then
+  echo "❌ Merge conflict detected against ${TARGET_BRANCH}"
+  exit 2
+fi
+echo "✅ No merge conflict detected against ${TARGET_BRANCH}"
+
+echo "[3/4] Running backend checks"
+pnpm --filter @workspace/api-server run typecheck
+pnpm --filter @workspace/api-server test
+
+echo "[4/4] Running frontend checks"
+pnpm --filter @workspace/web-app run typecheck
+PORT=3000 BASE_PATH=/ pnpm --filter @workspace/web-app run build
+
+echo "✅ Preflight passed"


### PR DESCRIPTION
### Motivation
- Add a reproducible preflight step for pull requests to detect merge conflicts early and run project checks before merging.

### Description
- Add a new executable script `scripts/preflight-pr.sh` that fetches the target branch, computes the merge-base, checks for merge conflicts using `git merge-tree`, and exits non-zero on conflict.
- The script runs backend checks with `pnpm --filter @workspace/api-server run typecheck` and `pnpm --filter @workspace/api-server test` and frontend checks with `pnpm --filter @workspace/web-app run typecheck` and a build run using `pnpm --filter @workspace/web-app run build`.
- Add a `preflight:pr` npm script entry in `package.json` that invokes `bash ./scripts/preflight-pr.sh`.
- The script is POSIX-compatible with `#!/usr/bin/env bash` and `set -euo pipefail`, and uses a shallow fetch (`--depth=200`) for the target branch.

### Testing
- No automated tests were executed as part of this PR itself; the change only adds the preflight script and an npm script entry.
- The preflight workflow is configured to run `pnpm --filter @workspace/api-server run typecheck`, `pnpm --filter @workspace/api-server test`, `pnpm --filter @workspace/web-app run typecheck`, and `pnpm --filter @workspace/web-app run build` when invoked by maintainers or CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4e4657a4832283199fd3b7c89354)