### PR TITLE
Inject configurable API_BASE into Pages with health check; ensure pgcrypto and create missing DB tables; enable session table auto-create

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -42,13 +42,40 @@ jobs:
           mkdir -p _site
           cp artifacts/web-app/index.html _site/index.html
           if [ -n "$API_BASE_URL" ]; then
-            sed -i "s|const API_BASE = '/api'|const API_BASE = '${API_BASE_URL}'|g" _site/index.html
+            ESCAPED_API_BASE_URL="$(printf '%s' "$API_BASE_URL" | sed 's/[&\\]/\\&/g')"
+            sed -i "s|<script src=\"https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js\"></script>|<script>window.__API_BASE__='${ESCAPED_API_BASE_URL}';</script>\\
+  <script src=\"https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js\"></script>|" _site/index.html
             echo "Injected API_BASE_URL: ${API_BASE_URL}"
           else
             echo "API_BASE_URL secret not set — using default /api"
           fi
           [ -f artifacts/web-app/public/favicon.svg ] && cp artifacts/web-app/public/favicon.svg _site/favicon.svg || true
           [ -f artifacts/web-app/public/opengraph.jpg ] && cp artifacts/web-app/public/opengraph.jpg _site/opengraph.jpg || true
+
+      - name: Verify API health before deploy
+        env:
+          API_BASE_URL: ${{ secrets.API_BASE_URL }}
+        run: |
+          if [ -z "$API_BASE_URL" ]; then
+            echo "API_BASE_URL secret not set; skip API health check"
+            exit 0
+          fi
+          CANDIDATE_1="${API_BASE_URL%/}/health"
+          CANDIDATE_2="${API_BASE_URL%/}/api/health"
+          echo "Trying health endpoint: $CANDIDATE_1"
+          if curl -fsS --max-time 20 "$CANDIDATE_1" >/tmp/api-health.txt; then
+            echo "API health ok via $CANDIDATE_1"
+            cat /tmp/api-health.txt
+            exit 0
+          fi
+          echo "Trying health endpoint: $CANDIDATE_2"
+          if curl -fsS --max-time 20 "$CANDIDATE_2" >/tmp/api-health.txt; then
+            echo "API health ok via $CANDIDATE_2"
+            cat /tmp/api-health.txt
+            exit 0
+          fi
+          echo "API health check failed on both candidates"
+          exit 1
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/artifacts/api-server/src/app.ts
+++ b/artifacts/api-server/src/app.ts
@@ -60,7 +60,7 @@ app.use(
     store: new PgStore({
       pool,
       tableName: "user_sessions",
-      createTableIfMissing: false,
+      createTableIfMissing: true,
     }),
     secret: process.env.SESSION_SECRET,
     resave: false,

--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -2,9 +2,49 @@ import app from "./app";
 import { logger } from "./lib/logger";
 import { pool } from "@workspace/db";
 
+async function ensurePgcryptoExtension(client: {
+  query: (sql: string) => Promise<unknown>;
+}) {
+  try {
+    await client.query(`CREATE EXTENSION IF NOT EXISTS pgcrypto`);
+  } catch (err) {
+    logger.warn({ err }, "migration.pgcrypto_unavailable");
+  }
+}
+
 async function runMigrations() {
   const client = await pool.connect();
   try {
+    await ensurePgcryptoExtension(client);
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS users (
+        id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+        email varchar UNIQUE,
+        password_hash varchar,
+        replit_user_id varchar UNIQUE,
+        first_name varchar,
+        last_name varchar,
+        profile_image_url varchar,
+        email_verified boolean NOT NULL DEFAULT false,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now()
+      )
+    `);
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS profiles (
+        id varchar PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+        username varchar,
+        display_name varchar,
+        avatar_url varchar,
+        bio text,
+        city varchar NOT NULL DEFAULT 'Bangkok',
+        verified_status boolean NOT NULL DEFAULT false,
+        rating_avg numeric(3, 2) NOT NULL DEFAULT '0',
+        successful_deals_count integer NOT NULL DEFAULT 0,
+        notification_settings text NOT NULL DEFAULT '{}',
+        created_at timestamptz NOT NULL DEFAULT now()
+      )
+    `);
     await client.query(
       `ALTER TABLE items ADD COLUMN IF NOT EXISTS image_urls text[] NOT NULL DEFAULT '{}'`,
     );

--- a/artifacts/web-app/index.html
+++ b/artifacts/web-app/index.html
@@ -2884,9 +2884,11 @@ h1,h2,h3{font-weight:900;}
       return document.getElementById(id);
     }
 
-    const API_BASE = (location.hostname === 'localhost' || location.hostname === '127.0.0.1')
-      ? '/api'
-      : 'https://qxwap-api.onrender.com/api';
+    const API_BASE = window.__API_BASE__ || (
+      (location.hostname === 'localhost' || location.hostname === '127.0.0.1')
+        ? '/api'
+        : 'https://qxwap-api.onrender.com/api'
+    );
 
     function apiErrorMessage(status){
       if(!status) return 'ไม่สามารถเชื่อมต่อ server ได้';


### PR DESCRIPTION
### Motivation
- Allow the deployed web site to use a configurable API base URL injected at Pages deploy time so non-default API endpoints can be targeted.
- Fail fast during Pages deployment if the configured API host is unhealthy to avoid publishing a broken frontend.
- Ensure the API server has required DB primitives available and that session storage can auto-create its table to simplify deployments.

### Description
- Update GitHub Actions `deploy-pages.yml` to escape and inject `API_BASE_URL` into the generated `_site/index.html` via a `window.__API_BASE__` script inserted before the Supabase script.
- Add a `Verify API health before deploy` step that probes both `${API_BASE_URL%/}/health` and `${API_BASE_URL%/}/api/health` and fails the job if neither responds successfully.
- Modify `artifacts/web-app/index.html` to use `window.__API_BASE__` as the API base with the existing localhost/production fallback when the variable is not present.
- In the API server, add an `ensurePgcryptoExtension` call and create missing `users` and `profiles` tables (and ensure other migrations/additional columns) during startup migrations, and set `createTableIfMissing: true` for the Postgres session store.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4e4657a4832283199fd3b7c89354)