### PR TITLE
Fix signin profile schema migration

### DIFF
--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -45,6 +45,16 @@ async function runMigrations() {
         created_at timestamptz NOT NULL DEFAULT now()
       )
     `);
+    await client.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS username varchar`);
+    await client.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS display_name varchar`);
+    await client.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS avatar_url varchar`);
+    await client.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS bio text`);
+    await client.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS city varchar NOT NULL DEFAULT 'Bangkok'`);
+    await client.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS verified_status boolean NOT NULL DEFAULT false`);
+    await client.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS rating_avg numeric(3, 2) NOT NULL DEFAULT '0'`);
+    await client.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS successful_deals_count integer NOT NULL DEFAULT 0`);
+    await client.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS notification_settings text NOT NULL DEFAULT '{}'`);
+    await client.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now()`);
     await client.query(`
       CREATE TABLE IF NOT EXISTS user_sessions (
         sid varchar PRIMARY KEY NOT NULL,
@@ -139,8 +149,6 @@ async function runMigrations() {
         UNIQUE(blocker_id, blocked_id)
       )
     `);
-    await client.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS bio text`);
-    await client.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS notification_settings text NOT NULL DEFAULT '{}'`);
     await client.query(`ALTER TABLE offer_messages ADD COLUMN IF NOT EXISTS image_url text`);
     await client.query(`
       CREATE TABLE IF NOT EXISTS follows (


### PR DESCRIPTION
### Motivation
Production login reaches the backend, but existing-user signin can still return `Internal server error` after signup correctly reports that the email already exists. That indicates the Pages/API base issue is fixed and the remaining blocker is backend schema/session handling during signin.

### Changes
- Make startup migrations idempotently add all expected `profiles` columns even when the table already exists from an older schema.
- This targets the likely signin failure path where `ensureProfile()` reads or inserts via the Drizzle `profilesTable` schema and fails if production has an older `profiles` table missing columns such as `display_name`, `avatar_url`, `city`, or notification/rating fields.

### Verification needed
After merge/deploy backend:
- `GET /api/health` should still pass.
- Existing-user `POST /api/auth/signin` should no longer fail because of missing profile columns.
- Bad credentials should return 401, not 500.

### Notes
This PR does not change GitHub Pages or API base configuration.