### PR TITLE
Fix Render startup migration for optional deal links

### DIFF
--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -86,7 +86,7 @@ async function runMigrations() {
         id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
         reporter_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
         reported_user_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-        deal_id varchar REFERENCES deals(id) ON DELETE SET NULL,
+        deal_id varchar,
         reason varchar NOT NULL,
         detail text,
         status varchar NOT NULL DEFAULT 'open',
@@ -131,7 +131,7 @@ async function runMigrations() {
     await client.query(`
       CREATE TABLE IF NOT EXISTS reviews (
         id varchar PRIMARY KEY DEFAULT gen_random_uuid(),
-        deal_id varchar NOT NULL REFERENCES deals(id) ON DELETE CASCADE,
+        deal_id varchar NOT NULL,
         reviewer_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
         reviewee_id varchar NOT NULL REFERENCES users(id) ON DELETE CASCADE,
         rating integer NOT NULL CHECK (rating BETWEEN 1 AND 5),


### PR DESCRIPTION
### Motivation
The latest Render deploy fails during startup migrations with:

`foreign key constraint "disputes_deal_id_fkey" cannot be implemented`

This blocks the API server from starting even though `/api/health` and auth fixes are otherwise ready.

### Changes
- Make `disputes.deal_id` an optional `varchar` column without creating a foreign key during startup migration.
- Make `reviews.deal_id` a `varchar NOT NULL` column without creating a foreign key during startup migration.

These tables are auxiliary and should not prevent the production API from booting when an existing production database has an older or mismatched `deals.id` column type.

### Verification needed
After merge and backend redeploy:
- Render startup migration should pass.
- `GET /api/health` should return `{ "status": "ok" }`.
- Re-test signup/signin.

### Notes
This only changes startup migration SQL. It does not modify frontend or GitHub Pages.