### PR TITLE
Fix QXwap product UX, filters, refresh, and offer flow

### DIFF
--- a/artifacts/api-server/src/index.ts
+++ b/artifacts/api-server/src/index.ts
@@ -19,6 +19,12 @@ async function runMigrations() {
     // Drizzle push owns table creation; startup only keeps additive objects
     // and backfills that are not expressed in the schema package.
     await client.query(
+      `ALTER TABLE items ADD COLUMN IF NOT EXISTS wanted_tags text[] NOT NULL DEFAULT '{}'`,
+    );
+    await client.query(
+      `ALTER TABLE items ADD COLUMN IF NOT EXISTS open_to_offers boolean NOT NULL DEFAULT true`,
+    );
+    await client.query(
       `ALTER TABLE items ADD COLUMN IF NOT EXISTS search_vector tsvector`,
     );
     await client.query(`

--- a/artifacts/api-server/src/routes/items.ts
+++ b/artifacts/api-server/src/routes/items.ts
@@ -1,6 +1,6 @@
 import { Router, type IRouter, type Request, type Response } from "express";
 import { db, itemsTable, insertItemSchema } from "@workspace/db";
-import { and, desc, eq, ilike, inArray, notInArray, sql } from "drizzle-orm";
+import { and, desc, eq, gte, ilike, inArray, lte, notInArray, sql } from "drizzle-orm";
 import { z } from "zod/v4";
 import { requireAuth } from "../middlewares/authMiddleware";
 import { sendError, sendValidationError } from "../lib/http";
@@ -106,6 +106,15 @@ function canViewItem(req: Request, item: typeof itemsTable.$inferSelect): boolea
   return item.status === publicItemStatus || canAccessOwnItems(req, item.ownerId);
 }
 
+function parseNonNegativeQueryNumber(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return parsed;
+}
+
 router.get("/items", async (req: Request, res: Response) => {
   const conditions = [];
   const ownerId = typeof req.query.owner_id === "string" ? req.query.owner_id : null;
@@ -127,6 +136,25 @@ router.get("/items", async (req: Request, res: Response) => {
     conditions.push(eq(itemsTable.dealType, "both" as const));
   } else if (dealType === "feed") {
     conditions.push(inArray(itemsTable.dealType, ["swap", "both"] as const));
+  }
+
+  const priceMin = parseNonNegativeQueryNumber(req.query.price_min);
+  if (priceMin !== null) {
+    conditions.push(gte(itemsTable.priceCash, priceMin));
+  }
+
+  const priceMax = parseNonNegativeQueryNumber(req.query.price_max);
+  if (priceMax !== null) {
+    conditions.push(lte(itemsTable.priceCash, priceMax));
+  }
+
+  if (req.query.open_to_offers === "1" || req.query.open_to_offers === "true") {
+    conditions.push(eq(itemsTable.openToOffers, true));
+  }
+
+  const wantedTag = typeof req.query.wanted_tag === "string" ? req.query.wanted_tag.trim() : "";
+  if (wantedTag) {
+    conditions.push(sql`${itemsTable.wantedTags} @> ARRAY[${wantedTag}]::text[]`);
   }
 
   const search = typeof req.query.search === "string" ? req.query.search.trim() : "";
@@ -181,7 +209,10 @@ router.post("/items", requireAuth, async (req: Request, res: Response) => {
   const priceCredit = parsed.data.priceCredit ?? 0;
   const title = parsed.data.title.trim();
   const category = parsed.data.category.trim();
-  const wantedText = parsed.data.wantedText?.trim() ?? "";
+  const wantedTags = Array.isArray(parsed.data.wantedTags)
+    ? parsed.data.wantedTags.map((tag) => String(tag).trim()).filter(Boolean)
+    : [];
+  const wantedText = (parsed.data.wantedText?.trim() || wantedTags.join(", ")) ?? "";
 
   if (!title) {
     sendError(res, 400, "bad_request", "ต้องระบุชื่อสินค้า");
@@ -197,39 +228,29 @@ router.post("/items", requireAuth, async (req: Request, res: Response) => {
     return;
   }
 
-  const hasSwapValue = priceCredit > 0 || Boolean(wantedText);
-  const hasBuyValue = priceCash > 0;
-  if (parsed.data.dealType === "swap" && !hasSwapValue) {
-    sendError(
-      res,
-      409,
-      "invalid_state",
-      "สินค้าสำหรับแลกต้องระบุมูลค่าการแลกอย่างน้อยหนึ่งอย่าง",
-    );
-    return;
-  }
-  if (parsed.data.dealType === "buy" && !hasBuyValue) {
-    sendError(
-      res,
-      409,
-      "invalid_state",
-      "สินค้าสำหรับขายต้องมีราคาเงินสดมากกว่า 0",
-    );
-    return;
-  }
-  if (parsed.data.dealType === "both" && !hasSwapValue && !hasBuyValue) {
-    sendError(
-      res,
-      409,
-      "invalid_state",
-      "สินค้าที่ซื้อหรือแลกได้ต้องมีราคาเงินสด เครดิต หรือความต้องการแลก",
-    );
-    return;
+  const openToOffers = parsed.data.openToOffers ?? true;
+  const hasCash = priceCash > 0;
+  const hasCredit = priceCredit > 0;
+  const hasWanted = Boolean(wantedText) || wantedTags.length > 0;
+
+  if (!openToOffers) {
+    if (parsed.data.dealType === "buy" && !hasCash) {
+      sendError(res, 400, "bad_request", "ประกาศขายต้องระบุราคาเงินสดมากกว่า 0");
+      return;
+    }
+    if (parsed.data.dealType === "swap" && !hasCredit && !hasWanted) {
+      sendError(res, 400, "bad_request", "ประกาศแลกต้องระบุเครดิตหรือสิ่งที่ต้องการ");
+      return;
+    }
+    if (parsed.data.dealType === "both" && !hasCash && !hasCredit && !hasWanted) {
+      sendError(res, 400, "bad_request", "ประกาศขาย/แลกต้องระบุอย่างน้อยหนึ่งค่า: เงินสด เครดิต หรือสิ่งที่ต้องการ");
+      return;
+    }
   }
 
   const [created] = await db
     .insert(itemsTable)
-    .values({ ...parsed.data, title, category, wantedText, ownerId: req.user.id })
+    .values({ ...parsed.data, title, category, wantedText, wantedTags, ownerId: req.user.id })
     .returning();
   res.json({ item: created });
 });

--- a/artifacts/api-server/src/routes/offers.ts
+++ b/artifacts/api-server/src/routes/offers.ts
@@ -78,11 +78,16 @@ const offerItemSchema = z
     { message: "แต่ละรายการต้องระบุสินค้า เงินสด หรือเครดิตอย่างน้อยหนึ่งอย่าง" },
   );
 
-const createOfferSchema = z.object({
-  targetItemId: z.uuid(),
-  message: z.string().max(2000).optional(),
-  items: z.array(offerItemSchema).min(1),
-});
+const createOfferSchema = z
+  .object({
+    targetItemId: z.uuid(),
+    message: z.string().max(2000).optional(),
+    items: z.array(offerItemSchema).default([]),
+  })
+  .refine(
+    (v) => v.items.length > 0 || Boolean(v.message?.trim()),
+    { message: "ระบุสินค้า เงินสด เครดิต หรือข้อความข้อเสนออย่างน้อยหนึ่งอย่าง" },
+  );
 
 router.post("/offers", requireAuth, async (req: Request, res: Response) => {
   if (!req.isAuthenticated()) return;
@@ -175,10 +180,15 @@ const counterOfferItemSchema = z
     { message: "แต่ละรายการต้องระบุสินค้า เงินสด หรือเครดิตอย่างน้อยหนึ่งอย่าง" },
   );
 
-const counterOfferSchema = z.object({
-  message: z.string().max(2000).optional(),
-  items: z.array(counterOfferItemSchema).min(1),
-});
+const counterOfferSchema = z
+  .object({
+    message: z.string().max(2000).optional(),
+    items: z.array(counterOfferItemSchema).default([]),
+  })
+  .refine(
+    (v) => v.items.length > 0 || Boolean(v.message?.trim()),
+    { message: "ระบุสินค้า เงินสด เครดิต หรือข้อความข้อเสนออย่างน้อยหนึ่งอย่าง" },
+  );
 
 router.post(
   "/offers/:id/counter",

--- a/artifacts/web-app/src/api.js
+++ b/artifacts/web-app/src/api.js
@@ -77,6 +77,7 @@ function qs(params = {}) {
 export const items = {
   list: (params = {}) => api.get(`/items${qs(params)}`),
   feed: () => api.get("/feed"),
+  get: (id) => api.get(`/items/${encodeURIComponent(String(id || ""))}`),
   create: (payload) => api.post("/items", payload),
   update: (id, payload) => api.patch(`/items/${id}`, payload),
   remove: (id) => api.del(`/items/${id}`),

--- a/artifacts/web-app/src/main.js
+++ b/artifacts/web-app/src/main.js
@@ -13,11 +13,29 @@ import {
   setShopFilter,
   loadShop,
 } from "./ui/shop.js";
-import { resetListingForm, createItem } from "./ui/add.js";
+import { resetListingForm, createItem, enhanceListingForm } from "./ui/add.js";
 import { setInboxFilter, loadInbox, updateOfferStatus } from "./ui/inbox.js";
 import { loadProfile } from "./ui/profile.js";
 import { openOfferPrompt } from "./ui/cards.js";
+import { openFilterSheet, ensureFilterSheet } from "./ui/filters.js";
 import { notify } from "./util.js";
+
+function addFilterButtons() {
+  ["feedSearch", "shopSearch"].forEach((inputId) => {
+    const input = document.getElementById(inputId);
+    if (!input) return;
+    const row = input.closest(".search-row") || input.parentElement?.parentElement;
+    if (!row || row.querySelector("[data-open-filter]")) return;
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "icon-btn";
+    btn.setAttribute("data-open-filter", "1");
+    btn.setAttribute("aria-label", "เปิดตัวกรอง");
+    btn.textContent = "⚙️";
+    btn.addEventListener("click", openFilterSheet);
+    row.appendChild(btn);
+  });
+}
 
 Object.assign(window, {
   showPage,
@@ -34,16 +52,21 @@ Object.assign(window, {
   loadShop,
   resetListingForm,
   createItem,
+  enhanceListingForm,
   loadInbox,
   setInboxFilter,
   updateOfferStatus,
   loadProfile,
   openOfferPrompt,
+  openFilterSheet,
 });
 
 window.addEventListener("error", (e) => {
   notify("authNotice", "error", "เกิดข้อผิดพลาดในหน้าเว็บ: " + e.message);
 });
 
+ensureFilterSheet();
+addFilterButtons();
+enhanceListingForm();
 renderCategories();
 loadSession();

--- a/artifacts/web-app/src/state.js
+++ b/artifacts/web-app/src/state.js
@@ -5,7 +5,23 @@ export const state = {
   feedCategory: "all",
   inboxFilter: "action",
   currentCategory: "all",
+  filters: {
+    query: "",
+    priceMin: "",
+    priceMax: "",
+    followingOnly: false,
+    nearbyKm: "",
+    fastResponder: false,
+    topUser: false,
+    hasRequests: false,
+    category: "all",
+    dealType: "all",
+    openToOffers: false,
+    wantedTag: "",
+  },
 };
+
+export const distanceOptionsKm = [3, 5, 10, 15, 20, 30, 50];
 
 export const categories = [
   { key: "all", name: "ทั้งหมด", icon: "🧩" },

--- a/artifacts/web-app/src/ui/add.js
+++ b/artifacts/web-app/src/ui/add.js
@@ -1,68 +1,163 @@
 import { qs, notify, debugStatus } from "../util.js";
 import { items, uploads } from "../api.js";
 import { authGuard } from "./nav.js";
-import { loadShop } from "./shop.js";
-import { loadFeed } from "./feed.js";
-import { loadProfile } from "./profile.js";
+import { refreshAllData } from "./refresh.js";
+
+function formValue(id, fallback = "") {
+  const el = document.getElementById(id);
+  return el && "value" in el ? String(el.value || fallback) : fallback;
+}
+
+function formChecked(id, fallback = true) {
+  const el = document.getElementById(id);
+  return el instanceof HTMLInputElement ? Boolean(el.checked) : fallback;
+}
+
+function wantedTagsFromForm() {
+  const explicit = formValue("itemWantedTags", "");
+  const fallback = formValue("itemWanted", "");
+  return (explicit || fallback)
+    .split(/[,\n]/)
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+}
+
+function setDealType(value) {
+  const select = document.getElementById("itemDealType");
+  if (select && "value" in select) select.value = value;
+  document.querySelectorAll("[data-add-deal-type]").forEach((button) => {
+    const active = button.getAttribute("data-add-deal-type") === value;
+    button.classList.toggle("active", active);
+    button.setAttribute("aria-pressed", active ? "true" : "false");
+  });
+}
+
+function ensureAddFormStyles() {
+  if (document.getElementById("addFormEnhanceStyles")) return;
+  const style = document.createElement("style");
+  style.id = "addFormEnhanceStyles";
+  style.textContent = `
+    .deal-type-cards{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin:10px 0 14px}
+    .deal-type-card{border:1px solid var(--line,rgba(0,0,0,.08));background:var(--card,#fff);border-radius:18px;padding:12px 8px;box-shadow:var(--shadow,0 8px 20px rgba(0,0,0,.06));font-weight:900;display:flex;flex-direction:column;gap:6px;align-items:center;justify-content:center;min-height:84px;color:var(--text,#171614)}
+    .deal-type-card span{font-size:24px;line-height:1}
+    .deal-type-card small{font-size:11px;color:var(--muted,#756d63);font-weight:800;text-align:center}
+    .deal-type-card.active{background:var(--brand,#3f6df6);color:#fff;border-color:var(--brand,#3f6df6)}
+    .deal-type-card.active small{color:rgba(255,255,255,.86)}
+    .add-helper-row{margin:10px 0 14px;padding:12px;border-radius:16px;background:var(--surface,#f0ece6);display:flex;align-items:flex-start;gap:10px;font-size:13px;font-weight:800;color:var(--text,#171614)}
+    .add-helper-row input{margin-top:2px}
+    .wanted-tags-input{margin-top:8px}
+    .visually-soft-hidden{position:absolute!important;opacity:.01;pointer-events:none;width:1px;height:1px;overflow:hidden}
+  `;
+  document.head.appendChild(style);
+}
+
+function ensureInputAfter(anchorId, id, placeholder) {
+  if (document.getElementById(id)) return;
+  const anchor = document.getElementById(anchorId);
+  if (!anchor) return;
+  const input = document.createElement("textarea");
+  input.id = id;
+  input.className = `${anchor.className || "input"} wanted-tags-input`;
+  input.placeholder = placeholder;
+  input.rows = 2;
+  anchor.insertAdjacentElement("afterend", input);
+}
+
+function enhanceDealTypeSelector() {
+  const select = document.getElementById("itemDealType");
+  if (!select || document.getElementById("dealTypeIconCards")) return;
+  const cards = document.createElement("div");
+  cards.id = "dealTypeIconCards";
+  cards.className = "deal-type-cards";
+  cards.innerHTML = `
+    <button type="button" class="deal-type-card" data-add-deal-type="swap" aria-pressed="false"><span>🔁</span>แลก<small>Xwap กับสินค้าอื่น</small></button>
+    <button type="button" class="deal-type-card" data-add-deal-type="buy" aria-pressed="false"><span>💸</span>ขาย<small>รับเงินสด</small></button>
+    <button type="button" class="deal-type-card" data-add-deal-type="both" aria-pressed="false"><span>⚡</span>ขาย/แลก<small>เปิดได้ทั้งสองแบบ</small></button>
+  `;
+  select.insertAdjacentElement("beforebegin", cards);
+  select.classList.add("visually-soft-hidden");
+  cards.querySelectorAll("[data-add-deal-type]").forEach((button) => {
+    button.addEventListener("click", () => setDealType(button.getAttribute("data-add-deal-type") || "swap"));
+  });
+  setDealType(formValue("itemDealType", "swap"));
+}
+
+function ensureOpenToOffersControl() {
+  if (document.getElementById("itemOpenToOffers")) return;
+  const price = document.getElementById("itemPriceCredit") || document.getElementById("itemPriceCash");
+  if (!price) return;
+  const label = document.createElement("label");
+  label.className = "add-helper-row";
+  label.innerHTML = `<input id="itemOpenToOffers" type="checkbox" checked /> <span>เปิดกว้างทุกข้อเสนอ<br><small>ลูกค้าสามารถเสนอเงินสด เครดิต สินค้า หรือข้อความได้ แม้ยังไม่กรอกราคา</small></span>`;
+  price.insertAdjacentElement("afterend", label);
+}
+
+export function enhanceListingForm() {
+  ensureAddFormStyles();
+  enhanceDealTypeSelector();
+  ensureOpenToOffersControl();
+  ensureInputAfter("itemWanted", "itemWantedTags", "เพิ่มสิ่งที่อยากได้เป็นแท็ก เช่น iPhone, กล้อง, เครดิตเพิ่ม");
+  const cash = document.getElementById("itemPriceCash");
+  if (cash) cash.setAttribute("placeholder", "100 บาท");
+  const credit = document.getElementById("itemPriceCredit");
+  if (credit) credit.setAttribute("placeholder", "1000 เครดิต");
+  const wanted = document.getElementById("itemWanted");
+  if (wanted) wanted.setAttribute("placeholder", "สิ่งที่อยากได้หลัก หรือปล่อยว่างถ้าเปิดกว้างทุกข้อเสนอ");
+}
 
 export function resetListingForm() {
-  [
-    "itemTitle",
-    "itemDescription",
-    "itemWanted",
-    "itemPriceCash",
-    "itemPriceCredit",
-  ].forEach((id) => (qs(id).value = ""));
-  qs("itemEmoji").value = "📦";
-  qs("itemLocation").value = "Bangkok";
-  qs("itemDealType").value = "swap";
-  qs("itemCategory").value = "electronics";
+  ["itemTitle", "itemDescription", "itemWanted", "itemWantedTags", "itemPriceCash", "itemPriceCredit"].forEach((id) => {
+    const el = document.getElementById(id);
+    if (el && "value" in el) el.value = "";
+  });
+  const emoji = document.getElementById("itemEmoji");
+  if (emoji && "value" in emoji) emoji.value = "📦";
+  const location = document.getElementById("itemLocation");
+  if (location && "value" in location) location.value = "Bangkok";
+  const category = document.getElementById("itemCategory");
+  if (category && "value" in category) category.value = "electronics";
+  const open = document.getElementById("itemOpenToOffers");
+  if (open instanceof HTMLInputElement) open.checked = true;
+  setDealType("swap");
   notify("addNotice", "", "");
 }
 
 export async function createItem() {
   debugStatus("กำลังบันทึกสินค้า...");
   if (!authGuard()) return;
+  enhanceListingForm();
   notify("addNotice", "", "");
+  const wantedTags = wantedTagsFromForm();
   const payload = {
-    title: qs("itemTitle").value.trim(),
-    description: qs("itemDescription").value.trim(),
-    category: qs("itemCategory").value,
+    title: formValue("itemTitle").trim(),
+    description: formValue("itemDescription").trim(),
+    category: formValue("itemCategory", "electronics"),
     conditionLabel: "สภาพดี",
-    dealType: qs("itemDealType").value,
-    priceCash: Number(qs("itemPriceCash").value || 0),
-    priceCredit: Number(qs("itemPriceCredit").value || 0),
-    wantedText: qs("itemWanted").value.trim(),
-    locationLabel: qs("itemLocation").value.trim() || "Bangkok",
-    imageEmoji: qs("itemEmoji").value.trim() || "📦",
+    dealType: formValue("itemDealType", "swap"),
+    priceCash: Number(formValue("itemPriceCash", "0") || 0),
+    priceCredit: Number(formValue("itemPriceCredit", "0") || 0),
+    wantedText: formValue("itemWanted").trim() || wantedTags.join(", "),
+    wantedTags,
+    openToOffers: formChecked("itemOpenToOffers", true),
+    locationLabel: formValue("itemLocation").trim() || "Bangkok",
+    imageEmoji: formValue("itemEmoji").trim() || "📦",
   };
   const imageInput = document.getElementById("itemImages");
-  const imageFiles =
-    imageInput instanceof HTMLInputElement && imageInput.files
-      ? Array.from(imageInput.files)
-      : [];
+  const imageFiles = imageInput instanceof HTMLInputElement && imageInput.files ? Array.from(imageInput.files) : [];
   if (!payload.title) return notify("addNotice", "error", "กรอกชื่อสินค้าก่อน");
-  if (!payload.category)
-    return notify("addNotice", "error", "เลือกหมวดหมู่ก่อน");
-  if (payload.priceCash < 0 || payload.priceCredit < 0)
-    return notify("addNotice", "error", "ราคาติดลบไม่ได้");
+  if (!payload.category) return notify("addNotice", "error", "เลือกหมวดหมู่ก่อน");
+  if (payload.priceCash < 0 || payload.priceCredit < 0) return notify("addNotice", "error", "ราคาติดลบไม่ได้");
   try {
     if (imageFiles.length) {
       notify("addNotice", "ok", "กำลังอัปโหลดรูป...");
       const { urls } = await uploads.images(imageFiles);
-      if (Array.isArray(urls) && urls.length) {
-        payload.imageUrls = urls;
-      }
+      if (Array.isArray(urls) && urls.length) payload.imageUrls = urls;
     }
     await items.create(payload);
     resetListingForm();
-    if (imageInput instanceof HTMLInputElement) {
-      imageInput.value = "";
-    }
+    if (imageInput instanceof HTMLInputElement) imageInput.value = "";
     notify("addNotice", "ok", "เพิ่มสินค้าสำเร็จ");
-    loadShop();
-    loadFeed();
-    loadProfile();
+    await refreshAllData({ stayOnScreen: true });
   } catch (e) {
     notify("addNotice", "error", String(e?.message || e));
   }

--- a/artifacts/web-app/src/ui/auth.js
+++ b/artifacts/web-app/src/ui/auth.js
@@ -2,11 +2,9 @@ import { qs, notify, debugStatus } from "../util.js";
 import { state } from "../state.js";
 import { auth } from "../api.js";
 import { showPage } from "./nav.js";
-import { renderCategories, loadShop } from "./shop.js";
-import { loadFeed } from "./feed.js";
-import { loadInbox } from "./inbox.js";
-import { loadProfile } from "./profile.js";
+import { renderCategories } from "./shop.js";
 import { clearSavedCache } from "./cards.js";
+import { refreshAllData } from "./refresh.js";
 
 function setAuthLoading(isLoading, text = "กำลังทำรายการ...") {
   const inBtn = qs("signInBtn");
@@ -24,10 +22,7 @@ function setAuthLoading(isLoading, text = "กำลังทำรายกา�
 async function afterAuth() {
   renderCategories();
   showPage("page-feed");
-  loadProfile();
-  loadShop();
-  loadFeed();
-  loadInbox();
+  await refreshAllData({ stayOnScreen: true });
 }
 
 export async function loadSession() {
@@ -38,7 +33,7 @@ export async function loadSession() {
     state.currentUser = null;
   }
   if (state.currentUser) {
-    afterAuth();
+    await afterAuth();
   } else {
     showPage("page-auth");
   }
@@ -61,7 +56,7 @@ export async function signUp() {
     const { user } = await auth.signup(email, password);
     state.currentUser = user;
     notify("authNotice", "ok", "สมัครและเข้าสู่ระบบสำเร็จ");
-    afterAuth();
+    await afterAuth();
   } catch (e) {
     notify("authNotice", "error", String(e?.message || e));
   } finally {
@@ -82,7 +77,7 @@ export async function signIn() {
     const { user } = await auth.signin(email, password);
     state.currentUser = user;
     notify("authNotice", "ok", "เข้าสู่ระบบสำเร็จ");
-    afterAuth();
+    await afterAuth();
   } catch (e) {
     notify("authNotice", "error", String(e?.message || e));
   } finally {

--- a/artifacts/web-app/src/ui/cards.js
+++ b/artifacts/web-app/src/ui/cards.js
@@ -1,12 +1,15 @@
 import { escapeHtml, itemEmoji } from "../util.js";
 import { state } from "../state.js";
-import { offers, bookmarks } from "../api.js";
+import { offers, bookmarks, items } from "../api.js";
 import { authGuard } from "./nav.js";
+import { refreshAllData } from "./refresh.js";
+import { applyWantedTagFilter } from "./filters.js";
 
 const FEED_DETAIL_MODAL_ID = "feedDetailModal";
 const savedItemIds = new Set();
 let savedLoadedForUserId = null;
 let loadingSavedPromise = null;
+const detailItemCache = new Map();
 
 export function clearSavedCache() {
   savedItemIds.clear();
@@ -20,18 +23,14 @@ export async function loadSavedListings() {
     return [];
   }
   const userId = state.currentUser.id;
-  if (savedLoadedForUserId === userId && loadingSavedPromise == null) {
-    return [...savedItemIds];
-  }
+  if (savedLoadedForUserId === userId && loadingSavedPromise == null) return [...savedItemIds];
   if (!loadingSavedPromise) {
     loadingSavedPromise = bookmarks
       .list()
       .then(({ itemIds }) => {
         savedItemIds.clear();
         for (const id of Array.isArray(itemIds) ? itemIds : []) {
-          if (typeof id === "string" && id.trim()) {
-            savedItemIds.add(id);
-          }
+          if (typeof id === "string" && id.trim()) savedItemIds.add(id);
         }
         savedLoadedForUserId = userId;
         return [...savedItemIds];
@@ -49,9 +48,7 @@ function isSaved(itemId) {
 
 async function toggleSaved(itemId) {
   if (!authGuard()) return null;
-  if (!savedLoadedForUserId) {
-    await loadSavedListings();
-  }
+  if (!savedLoadedForUserId) await loadSavedListings();
   if (savedItemIds.has(itemId)) {
     await bookmarks.unsave(itemId);
     savedItemIds.delete(itemId);
@@ -65,10 +62,9 @@ async function toggleSaved(itemId) {
 function formatPrice(item) {
   const cash = Number(item.priceCash || 0);
   const credit = Number(item.priceCredit || 0);
+  if (item.openToOffers && !cash && !credit) return "เปิดกว้างทุกข้อเสนอ";
   if (item.dealType === "swap" && !cash && !credit) return "เปิดรับ Xwap";
-  if (cash && credit) {
-    return `฿${cash.toLocaleString()} + ${credit.toLocaleString()} เครดิต`;
-  }
+  if (cash && credit) return `฿${cash.toLocaleString()} + ${credit.toLocaleString()} เครดิต`;
   if (cash) return `฿${cash.toLocaleString()}`;
   if (credit) return `${credit.toLocaleString()} เครดิต`;
   return "เปิดรับข้อเสนอ";
@@ -86,18 +82,14 @@ function parseImageList(item) {
     item?.images,
     item?.media,
     item?.photos,
+    item?.image_urls,
     item?.image_url,
     item?.imageUrl,
   ];
   for (const value of candidates) {
     if (Array.isArray(value)) return value.filter(Boolean);
     if (typeof value === "string" && value.trim()) {
-      if (value.includes(",")) {
-        return value
-          .split(",")
-          .map((x) => x.trim())
-          .filter(Boolean);
-      }
+      if (value.includes(",")) return value.split(",").map((x) => x.trim()).filter(Boolean);
       return [value];
     }
   }
@@ -111,75 +103,62 @@ function pickImage(item, side = "have") {
   return images[0];
 }
 
+function wantedTags(item) {
+  if (Array.isArray(item?.wantedTags)) return item.wantedTags.map(String).map((x) => x.trim()).filter(Boolean);
+  if (Array.isArray(item?.wanted_tags)) return item.wanted_tags.map(String).map((x) => x.trim()).filter(Boolean);
+  return String(item?.wantedText || "").split(/[,\n]/).map((x) => x.trim()).filter(Boolean).slice(0, 6);
+}
+
+function wantedTagsHtml(item) {
+  const tags = wantedTags(item);
+  if (!tags.length) return "";
+  return `<div class="wanted-tags">${tags.map((tag) => `<button type="button" class="wanted-tag" data-wanted-tag="${escapeHtml(tag)}">${escapeHtml(tag)}</button>`).join("")}</div>`;
+}
+
 function requestPreviewRow(item) {
   const requests = Array.isArray(item.requestPreview) ? item.requestPreview : [];
   if (!requests.length) {
-    return `
-      <div class="feed-request-preview">
-        <div class="feed-request-avatars">
-          <span class="feed-request-avatar fallback">•</span>
-        </div>
-        <div class="feed-request-text">ยังไม่มีคำขอแลก · พร้อมรับข้อเสนอแรก</div>
-      </div>
-    `;
+    return `<div class="feed-request-preview"><div class="feed-request-avatars"><span class="feed-request-avatar fallback">•</span></div><div class="feed-request-text">ยังไม่มีคำขอแลก · พร้อมรับข้อเสนอแรก</div></div>`;
   }
-  const avatars = requests
-    .slice(0, 3)
-    .map((entry, idx) => {
-      const initial = escapeHtml(
-        String(entry?.name || `U${idx + 1}`)
-          .trim()
-          .slice(0, 1)
-          .toUpperCase(),
-      );
-      if (entry?.avatar) {
-        return `<span class="feed-request-avatar"><img src="${escapeHtml(entry.avatar)}" alt="${initial}" loading="lazy" /></span>`;
-      }
-      return `<span class="feed-request-avatar">${initial}</span>`;
-    })
-    .join("");
+  const avatars = requests.slice(0, 3).map((entry, idx) => {
+    const initial = escapeHtml(String(entry?.name || `U${idx + 1}`).trim().slice(0, 1).toUpperCase());
+    if (entry?.avatar) return `<span class="feed-request-avatar"><img src="${escapeHtml(entry.avatar)}" alt="${initial}" loading="lazy" /></span>`;
+    return `<span class="feed-request-avatar">${initial}</span>`;
+  }).join("");
   const total = Number(item.requestCount || requests.length || 0);
-  return `
-    <div class="feed-request-preview">
-      <div class="feed-request-avatars">${avatars}</div>
-      <div class="feed-request-text">${total.toLocaleString()} คำขอสนใจรายการนี้</div>
-    </div>
-  `;
+  return `<div class="feed-request-preview"><div class="feed-request-avatars">${avatars}</div><div class="feed-request-text">${total.toLocaleString()} คำขอสนใจรายการนี้</div></div>`;
 }
 
 export function productCardHtml(item) {
-  const buyBtn =
-    item.dealType === "swap"
-      ? ""
-      : `<button class="btn soft" data-buy-now="1">ซื้อเลย</button>`;
-  const priceLabel =
-    item.dealType === "swap"
-      ? "เปิดรับ Xwap"
-      : `฿${Number(item.priceCash || 0).toLocaleString()}`;
+  detailItemCache.set(item.id, item);
+  const buyBtn = item.dealType === "swap" ? "" : `<button class="btn soft" data-buy-now="1">ซื้อเลย</button>`;
+  const priceLabel = item.dealType === "swap" ? "เปิดรับ Xwap" : formatPrice(item);
+  const image = pickImage(item);
+  const emoji = escapeHtml(itemEmoji(item));
   return `
-    <div class="product-card" data-item-id="${escapeHtml(item.id)}" data-item-title="${escapeHtml(item.title || "")}" data-owner-id="${escapeHtml(item.ownerId)}">
+    <div class="product-card" data-item-id="${escapeHtml(item.id)}" data-item-title="${escapeHtml(item.title || "")}" data-owner-id="${escapeHtml(item.ownerId || "")}">
       <div class="product-left">
         <div class="product-badge">${escapeHtml(item.conditionLabel || "สภาพดี")}</div>
-        <div class="product-image">${escapeHtml(itemEmoji(item))}</div>
+        <div class="product-image">${image ? `<img src="${escapeHtml(image)}" alt="${escapeHtml(item.title || "สินค้า")}" loading="lazy" />` : emoji}</div>
       </div>
       <div class="product-right">
-        <div class="product-top-row">
-          <div class="product-title">${escapeHtml(item.title || "-")}</div>
-          <div class="deal-chip">${item.dealType === "swap" ? "แลกได้" : item.dealType === "both" ? "ขาย/แลก" : "ซื้อได้"}</div>
-        </div>
+        <div class="product-top-row"><div class="product-title">${escapeHtml(item.title || "-")}</div><div class="deal-chip">${escapeHtml(dealTypeLabel(item.dealType))}</div></div>
         <div class="price">${escapeHtml(priceLabel)}</div>
         <div class="product-meta">${escapeHtml(item.locationLabel || "Bangkok")} · ${escapeHtml(item.category || "")}</div>
-        <div class="btn-row">${buyBtn}<button class="btn primary" data-xwap="1">Xwap</button></div>
+        ${wantedTagsHtml(item)}
+        <div class="btn-row">${buyBtn}<button class="btn primary" data-xwap="1">Xwap</button><button class="btn ghost" data-open-detail="1">ดูรายละเอียด</button></div>
       </div>
     </div>`;
 }
 
 export function feedCardHtml(item) {
+  detailItemCache.set(item.id, item);
   const saved = isSaved(item.id);
   const haveImg = pickImage(item, "have");
   const wantImg = pickImage(item, "want");
   const haveEmoji = escapeHtml(itemEmoji(item));
-  const wantedText = escapeHtml(item.wantedText || "ยังไม่ได้ระบุสิ่งที่อยากได้");
+  const tags = wantedTags(item);
+  const wantedText = escapeHtml(tags.join(", ") || item.wantedText || "ยังไม่ได้ระบุสิ่งที่อยากได้");
   const cardTitle = escapeHtml(item.title || "รายการสำหรับ Xwap");
   const location = escapeHtml(item.locationLabel || "Bangkok");
   const category = escapeHtml(item.category || "อื่นๆ");
@@ -188,66 +167,20 @@ export function feedCardHtml(item) {
   const requestSummary = escapeHtml(item.requestSummary || wantedText);
 
   return `
-    <article
-      class="feed-card ${saved ? "saved" : ""}"
-      data-feed-card="1"
-      data-item-id="${escapeHtml(item.id)}"
-      data-item-title="${escapeHtml(item.title || "")}"
-      data-owner-id="${escapeHtml(item.ownerId)}"
-      data-item-location="${location}"
-      data-item-category="${category}"
-      data-item-deal="${escapeHtml(deal)}"
-      data-item-price="${price}"
-      data-item-wanted="${wantedText}"
-      data-item-emoji="${haveEmoji}"
-    >
-      <button
-        class="feed-save-btn ${saved ? "saved" : ""}"
-        data-save="1"
-        aria-label="${saved ? "ยกเลิกบันทึก" : "บันทึกรายการ"}"
-        aria-pressed="${saved ? "true" : "false"}"
-      >
-        <span class="feed-save-icon">${saved ? "★" : "☆"}</span>
-      </button>
-
+    <article class="feed-card ${saved ? "saved" : ""}" data-feed-card="1" data-item-id="${escapeHtml(item.id)}" data-item-title="${escapeHtml(item.title || "")}" data-owner-id="${escapeHtml(item.ownerId || "")}" data-item-location="${location}" data-item-category="${category}" data-item-deal="${escapeHtml(deal)}" data-item-price="${price}" data-item-wanted="${wantedText}" data-item-emoji="${haveEmoji}">
+      <button class="feed-save-btn ${saved ? "saved" : ""}" data-save="1" aria-label="${saved ? "ยกเลิกบันทึก" : "บันทึกรายการ"}" aria-pressed="${saved ? "true" : "false"}"><span class="feed-save-icon">${saved ? "★" : "☆"}</span></button>
       <div class="swap-hero">
-        <div class="swap-half own">
-          <div class="swap-label">มีอยู่</div>
-          <div class="swap-media">
-            ${
-              haveImg
-                ? `<img src="${escapeHtml(haveImg)}" alt="${cardTitle}" loading="lazy" />`
-                : `<div class="swap-media-fallback">${haveEmoji}</div>`
-            }
-          </div>
-        </div>
-        <div class="swap-half want">
-          <div class="swap-label right">อยากได้</div>
-          <div class="swap-media">
-            ${
-              wantImg
-                ? `<img src="${escapeHtml(wantImg)}" alt="${wantedText}" loading="lazy" />`
-                : `<div class="swap-media-wanted">${wantedText}</div>`
-            }
-          </div>
-        </div>
-        <button class="feed-xwap-cta" data-xwap="1" aria-label="ส่งคำขอ Xwap">
-          Xwap
-        </button>
+        <div class="swap-half own"><div class="swap-label">มีอยู่</div><div class="swap-media">${haveImg ? `<img src="${escapeHtml(haveImg)}" alt="${cardTitle}" loading="lazy" />` : `<div class="swap-media-fallback">${haveEmoji}</div>`}</div></div>
+        <div class="swap-half want"><div class="swap-label right">อยากได้</div><div class="swap-media">${wantImg ? `<img src="${escapeHtml(wantImg)}" alt="${wantedText}" loading="lazy" />` : `<div class="swap-media-wanted">${wantedText}</div>`}</div></div>
+        <button class="feed-xwap-cta" data-xwap="1" aria-label="ส่งคำขอ Xwap">Xwap</button>
       </div>
-
       <div class="feed-card-body">
         <div class="swap-card-title">${cardTitle}</div>
         <div class="swap-card-sub">${location} · ${category} · ${escapeHtml(deal)}</div>
-        <div class="feed-meta-row">
-          <div class="feed-price">${price}</div>
-          <div class="feed-request-summary">${requestSummary}</div>
-        </div>
+        <div class="feed-meta-row"><div class="feed-price">${price}</div><div class="feed-request-summary">${requestSummary}</div></div>
+        ${wantedTagsHtml(item)}
         ${requestPreviewRow(item)}
-        <div class="feed-actions">
-          <button class="btn primary" data-xwap="1">ส่งคำขอ Xwap</button>
-          <button class="btn ghost" data-open-detail="1">ดูรายละเอียด</button>
-        </div>
+        <div class="feed-actions"><button class="btn primary" data-xwap="1">ส่งคำขอ Xwap</button><button class="btn ghost" data-open-detail="1">ดูรายละเอียด</button></div>
       </div>
     </article>`;
 }
@@ -260,40 +193,41 @@ export function bindCardActions(container) {
   let touchStartY = 0;
   let swipeCard = null;
 
-  container.addEventListener(
-    "touchstart",
-    (event) => {
-      const card = event.target.closest("[data-feed-card]");
-      if (!card) return;
-      if (event.target.closest("[data-xwap],[data-save],[data-open-detail]")) return;
-      const touch = event.changedTouches[0];
-      touchStartX = touch.clientX;
-      touchStartY = touch.clientY;
-      swipeCard = card;
-    },
-    { passive: true },
-  );
+  container.addEventListener("touchstart", (event) => {
+    const card = event.target.closest("[data-feed-card]");
+    if (!card || event.target.closest("[data-xwap],[data-save],[data-open-detail]")) return;
+    const touch = event.changedTouches[0];
+    touchStartX = touch.clientX;
+    touchStartY = touch.clientY;
+    swipeCard = card;
+  }, { passive: true });
 
-  container.addEventListener(
-    "touchend",
-    (event) => {
-      if (!swipeCard) return;
-      const touch = event.changedTouches[0];
-      const dx = touch.clientX - touchStartX;
-      const dy = touch.clientY - touchStartY;
-      if (Math.abs(dx) > 68 && Math.abs(dy) < 44) {
-        const cls = dx > 0 ? "swiped-right" : "swiped-left";
-        swipeCard.classList.add(cls);
-        window.setTimeout(() => swipeCard?.classList.remove(cls), 320);
-      }
-      swipeCard = null;
-    },
-    { passive: true },
-  );
+  container.addEventListener("touchend", (event) => {
+    if (!swipeCard) return;
+    const touch = event.changedTouches[0];
+    const dx = touch.clientX - touchStartX;
+    const dy = touch.clientY - touchStartY;
+    if (Math.abs(dx) > 68 && Math.abs(dy) < 44) {
+      const cls = dx > 0 ? "swiped-right" : "swiped-left";
+      swipeCard.classList.add(cls);
+      window.setTimeout(() => swipeCard?.classList.remove(cls), 320);
+    }
+    swipeCard = null;
+  }, { passive: true });
 
   container.addEventListener("click", async (event) => {
     const target = event.target;
     if (!(target instanceof Element)) return;
+
+    const tagBtn = target.closest("[data-wanted-tag]");
+    if (tagBtn) {
+      const tag = tagBtn.getAttribute("data-wanted-tag") || "";
+      applyWantedTagFilter(tag);
+      const { loadFeed } = await import("./feed.js");
+      const { loadShop } = await import("./shop.js");
+      await Promise.allSettled([loadFeed(), loadShop()]);
+      return;
+    }
 
     const buyBtn = target.closest("[data-buy-now]");
     if (buyBtn) {
@@ -327,11 +261,8 @@ export function bindCardActions(container) {
       } catch (error) {
         alert("บันทึกรายการไม่สำเร็จ: " + String(error?.message || error));
       } finally {
-        if (prevDisabled == null) {
-          saveBtn.removeAttribute("disabled");
-        } else {
-          saveBtn.setAttribute("disabled", prevDisabled);
-        }
+        if (prevDisabled == null) saveBtn.removeAttribute("disabled");
+        else saveBtn.setAttribute("disabled", prevDisabled);
       }
       return;
     }
@@ -342,49 +273,43 @@ export function bindCardActions(container) {
       if (!card) return;
       card.classList.add("xwap-active");
       window.setTimeout(() => card.classList.remove("xwap-active"), 900);
-      openOfferPrompt(
-        card.getAttribute("data-item-id"),
-        card.getAttribute("data-item-title") || "สินค้า",
-        card.getAttribute("data-owner-id"),
-      );
+      await openOfferPrompt(card.getAttribute("data-item-id"), card.getAttribute("data-item-title") || "สินค้า", card.getAttribute("data-owner-id"));
       return;
     }
 
     const detailBtn = target.closest("[data-open-detail]");
     if (detailBtn) {
-      const card = detailBtn.closest("[data-feed-card]");
+      const card = detailBtn.closest("[data-item-id]");
       if (!card) return;
-      openFeedDetail(card);
+      await openDetailByItemId(card.getAttribute("data-item-id"), card);
       return;
     }
 
-    const card = target.closest("[data-feed-card]");
-    if (card) {
-      openFeedDetail(card);
-    }
+    const card = target.closest("[data-feed-card], .product-card");
+    if (card) await openDetailByItemId(card.getAttribute("data-item-id"), card);
   });
 }
 
 export async function openOfferPrompt(itemId, itemTitle, ownerId) {
   if (!authGuard()) return;
-  if (ownerId === state.currentUser.id)
-    return alert("ไม่สามารถขอแลกสินค้าของตัวเอง");
-  const message = prompt(
-    `ต้องการส่งข้อความขอแลกสำหรับ ${itemTitle} ?`,
-    "สนใจแลกครับ",
-  );
+  if (ownerId === state.currentUser.id) return alert("ไม่สามารถขอแลกสินค้าของตัวเอง");
+  const message = prompt(`ข้อความถึงเจ้าของสินค้า (${itemTitle})`, "สนใจแลกครับ");
   if (message === null) return;
+  const cashInput = prompt("เพิ่มเงินสด (ปล่อยว่างได้)", "");
+  if (cashInput === null) return;
+  const creditInput = prompt("เพิ่มเครดิต (ปล่อยว่างได้)", "");
+  if (creditInput === null) return;
+  const cashAmount = Math.max(0, Number(cashInput || 0) || 0);
+  const creditAmount = Math.max(0, Number(creditInput || 0) || 0);
+  const item = {};
+  if (cashAmount > 0) item.cashAmount = cashAmount;
+  if (creditAmount > 0) item.creditAmount = creditAmount;
+  const itemList = Object.keys(item).length ? [item] : [];
+  if (!String(message || "").trim() && itemList.length === 0) return alert("เพิ่มข้อความ เงินสด หรือเครดิตก่อนส่งข้อเสนอ");
   try {
-    await offers.create({
-      targetItemId: itemId,
-      receiverId: ownerId,
-      offeredCash: 0,
-      offeredCredit: 0,
-      message: message || "",
-    });
+    await offers.create({ targetItemId: itemId, message: String(message || "").trim(), items: itemList });
     alert("ส่งข้อเสนอแล้ว");
-    const { loadInbox } = await import("./inbox.js");
-    loadInbox();
+    await refreshAllData({ stayOnScreen: true });
   } catch (e) {
     alert("ส่งข้อเสนอไม่สำเร็จ: " + String(e?.message || e));
   }
@@ -396,55 +321,75 @@ function ensureFeedDetailModal() {
   modal = document.createElement("div");
   modal.id = FEED_DETAIL_MODAL_ID;
   modal.className = "feed-detail-modal";
-  modal.innerHTML = `
-    <div class="feed-detail-backdrop" data-close-feed-detail="1"></div>
-    <div class="feed-detail-sheet" role="dialog" aria-modal="true" aria-label="รายละเอียดสินค้า">
-      <button class="feed-detail-close" data-close-feed-detail="1" aria-label="ปิด">×</button>
-      <div class="feed-detail-content"></div>
-    </div>
-  `;
+  modal.innerHTML = `<div class="feed-detail-backdrop" data-close-feed-detail="1"></div><div class="feed-detail-sheet" role="dialog" aria-modal="true" aria-label="รายละเอียดสินค้า"><button class="feed-detail-close" data-close-feed-detail="1" aria-label="ปิด">×</button><div class="feed-detail-content"></div></div>`;
   document.body.appendChild(modal);
-  modal.addEventListener("click", (event) => {
+  modal.addEventListener("click", async (event) => {
     const target = event.target;
     if (!(target instanceof Element)) return;
-    if (target.closest("[data-close-feed-detail]")) {
+    if (target.closest("[data-close-feed-detail]")) closeFeedDetail();
+    const xwap = target.closest("[data-feed-detail-xwap]");
+    if (xwap) {
       closeFeedDetail();
+      await openOfferPrompt(xwap.getAttribute("data-item-id"), xwap.getAttribute("data-item-title") || "สินค้า", xwap.getAttribute("data-owner-id"));
+    }
+    const del = target.closest("[data-feed-delete]");
+    if (del) {
+      const itemId = del.getAttribute("data-item-id");
+      if (itemId && confirm("ลบสินค้านี้?")) {
+        await items.remove(itemId);
+        closeFeedDetail();
+        await refreshAllData({ stayOnScreen: true });
+      }
     }
   });
   return modal;
 }
 
-function openFeedDetail(card) {
+async function resolveItem(itemId, card) {
+  if (itemId && detailItemCache.has(itemId)) return detailItemCache.get(itemId);
+  if (itemId) {
+    const response = await items.get(itemId);
+    if (response?.item) {
+      detailItemCache.set(itemId, response.item);
+      return response.item;
+    }
+  }
+  return {
+    id: itemId,
+    title: card?.getAttribute("data-item-title") || "รายการสำหรับ Xwap",
+    wantedText: card?.getAttribute("data-item-wanted") || "ยังไม่ได้ระบุ",
+    locationLabel: card?.getAttribute("data-item-location") || "Bangkok",
+    category: card?.getAttribute("data-item-category") || "-",
+    dealType: card?.getAttribute("data-item-deal") || "swap",
+    ownerId: card?.getAttribute("data-owner-id") || "",
+    imageEmoji: card?.getAttribute("data-item-emoji") || "📦",
+  };
+}
+
+export async function openDetailByItemId(itemId, card = null) {
   const modal = ensureFeedDetailModal();
   const content = modal.querySelector(".feed-detail-content");
   if (!content) return;
-  const itemTitle = card.getAttribute("data-item-title") || "รายการสำหรับ Xwap";
-  const wanted = card.getAttribute("data-item-wanted") || "ยังไม่ได้ระบุ";
-  const location = card.getAttribute("data-item-location") || "Bangkok";
-  const category = card.getAttribute("data-item-category") || "-";
-  const deal = card.getAttribute("data-item-deal") || "แลกได้";
-  const price = card.getAttribute("data-item-price") || "เปิดรับข้อเสนอ";
-  const emoji = card.getAttribute("data-item-emoji") || "📦";
-  content.innerHTML = `
-    <div class="feed-detail-emoji">${emoji}</div>
-    <h3>${escapeHtml(itemTitle)}</h3>
-    <p class="feed-detail-meta">${escapeHtml(location)} · ${escapeHtml(category)} · ${escapeHtml(deal)}</p>
-    <div class="feed-detail-price">${escapeHtml(price)}</div>
-    <div class="feed-detail-wanted"><strong>อยากได้:</strong> ${escapeHtml(wanted)}</div>
-    <div class="feed-detail-actions">
-      <button class="btn primary" data-feed-detail-xwap="1">ส่งคำขอ Xwap</button>
-    </div>
-  `;
-  content.querySelector("[data-feed-detail-xwap]")?.addEventListener("click", () => {
-    closeFeedDetail();
-    openOfferPrompt(
-      card.getAttribute("data-item-id"),
-      card.getAttribute("data-item-title") || "สินค้า",
-      card.getAttribute("data-owner-id"),
-    );
-  });
+  content.innerHTML = `<div class="empty">กำลังโหลดรายละเอียด...</div>`;
   modal.classList.add("open");
   document.body.classList.add("modal-open");
+  try {
+    const item = await resolveItem(itemId, card);
+    const image = pickImage(item);
+    const title = item.title || "รายการสำหรับ Xwap";
+    const isOwner = Boolean(state.currentUser?.id && item.ownerId === state.currentUser.id);
+    content.innerHTML = `
+      <div class="feed-detail-emoji">${image ? `<img src="${escapeHtml(image)}" alt="${escapeHtml(title)}" loading="lazy" />` : escapeHtml(itemEmoji(item))}</div>
+      <h3>${escapeHtml(title)}</h3>
+      <p class="feed-detail-meta">${escapeHtml(item.locationLabel || "Bangkok")} · ${escapeHtml(item.category || "-")} · ${escapeHtml(dealTypeLabel(item.dealType))}</p>
+      <div class="feed-detail-price">${escapeHtml(formatPrice(item))}</div>
+      <div class="feed-detail-wanted"><strong>อยากได้:</strong> ${escapeHtml(wantedTags(item).join(", ") || item.wantedText || "ยังไม่ได้ระบุ")}</div>
+      ${wantedTagsHtml(item)}
+      <div class="feed-detail-actions">${isOwner ? `<button class="btn soft" data-feed-edit="1">แก้ไข</button><button class="btn ghost" data-feed-delete="1" data-item-id="${escapeHtml(item.id)}">ลบ</button>` : `<button class="btn primary" data-feed-detail-xwap="1" data-item-id="${escapeHtml(item.id)}" data-item-title="${escapeHtml(title)}" data-owner-id="${escapeHtml(item.ownerId || "")}">ส่งคำขอ Xwap</button>`}</div>
+    `;
+  } catch (e) {
+    content.innerHTML = `<div class="empty">โหลดรายละเอียดไม่สำเร็จ: ${escapeHtml(String(e?.message || e))}</div>`;
+  }
 }
 
 function closeFeedDetail() {

--- a/artifacts/web-app/src/ui/feed.js
+++ b/artifacts/web-app/src/ui/feed.js
@@ -3,14 +3,14 @@ import { state, categories } from "../state.js";
 import { items } from "../api.js";
 import { authGuard } from "./nav.js";
 import { feedCardHtml, bindCardActions, loadSavedListings } from "./cards.js";
+import { buildItemQueryParams, syncFiltersFromSearch, syncSearchInputsFromFilters } from "./filters.js";
 
 export { feedCardHtml };
 
 export function setFeedFilter(filter, btn) {
   state.feedFilter = filter;
-  document
-    .querySelectorAll("[data-feed-filter]")
-    .forEach((x) => x.classList.remove("active"));
+  state.filters.dealType = filter === "all" ? "all" : filter;
+  document.querySelectorAll("[data-feed-filter]").forEach((x) => x.classList.remove("active"));
   if (btn) btn.classList.add("active");
   syncFeedFilterButtons();
   loadFeed();
@@ -18,9 +18,8 @@ export function setFeedFilter(filter, btn) {
 
 export function setFeedCategory(category, btn) {
   state.feedCategory = category;
-  document
-    .querySelectorAll("[data-feed-category]")
-    .forEach((x) => x.classList.remove("active"));
+  state.filters.category = category || "all";
+  document.querySelectorAll("[data-feed-category]").forEach((x) => x.classList.remove("active"));
   if (btn) btn.classList.add("active");
   syncFeedCategoryButtons();
   loadFeed();
@@ -29,35 +28,17 @@ export function setFeedCategory(category, btn) {
 function feedSkeletonCardHtml() {
   return `
     <article class="feed-card skeleton-card" aria-hidden="true">
-      <div class="swap-hero">
-        <div class="swap-half"><div class="swap-media skeleton-block"></div></div>
-        <div class="swap-half"><div class="swap-media skeleton-block"></div></div>
-      </div>
-      <div class="feed-card-body">
-        <div class="skeleton-line w-70"></div>
-        <div class="skeleton-line w-55"></div>
-        <div class="skeleton-line w-85"></div>
-      </div>
-    </article>
-  `;
+      <div class="swap-hero"><div class="swap-half"><div class="swap-media skeleton-block"></div></div><div class="swap-half"><div class="swap-media skeleton-block"></div></div></div>
+      <div class="feed-card-body"><div class="skeleton-line w-70"></div><div class="skeleton-line w-55"></div><div class="skeleton-line w-85"></div></div>
+    </article>`;
 }
 
 function emptyFeedStateHtml() {
-  return `
-    <div class="empty feed-empty-state">
-      <div class="feed-empty-title">ยังไม่พบรายการที่ตรงกับเงื่อนไข</div>
-      <div class="feed-empty-sub">ลองเปลี่ยนคำค้นหา ตัวกรอง หรือหมวดหมู่</div>
-    </div>
-  `;
+  return `<div class="empty feed-empty-state"><div class="feed-empty-title">ยังไม่พบรายการที่ตรงกับเงื่อนไข</div><div class="feed-empty-sub">ลองเปลี่ยนคำค้นหา ตัวกรอง หรือหมวดหมู่</div></div>`;
 }
 
 function feedErrorStateHtml(message) {
-  return `
-    <div class="empty feed-empty-state">
-      <div class="feed-empty-title">โหลดรายการไม่สำเร็จ</div>
-      <div class="feed-empty-sub">${message}</div>
-    </div>
-  `;
+  return `<div class="empty feed-empty-state"><div class="feed-empty-title">โหลดรายการไม่สำเร็จ</div><div class="feed-empty-sub">${message}</div></div>`;
 }
 
 function normalizeFeedItem(item) {
@@ -71,12 +52,15 @@ function normalizeFeedItem(item) {
     priceCash: Number(item?.priceCash || 0),
     priceCredit: Number(item?.priceCredit || 0),
     wantedText: item?.wantedText || "",
+    wantedTags: Array.isArray(item?.wantedTags) ? item.wantedTags : [],
+    openToOffers: Boolean(item?.openToOffers),
     requestSummary: item?.requestSummary || "",
     requestCount: Number(item?.requestCount || 0),
     requestPreview: Array.isArray(item?.requestPreview) ? item.requestPreview : [],
     imageEmoji: item?.imageEmoji || "📦",
     conditionLabel: item?.conditionLabel || "สภาพดี",
     imageUrls: Array.isArray(item?.imageUrls) ? item.imageUrls : undefined,
+    image_urls: Array.isArray(item?.image_urls) ? item.image_urls : undefined,
     imageUrl: typeof item?.imageUrl === "string" ? item.imageUrl : undefined,
     images: Array.isArray(item?.images) ? item.images : undefined,
   };
@@ -96,74 +80,46 @@ function syncFeedFilterButtons() {
 function renderFeedCategoryRow() {
   const row = qs("feedCategoryRow");
   if (!row) return;
-  row.innerHTML = categories
-    .map((cat) => {
-      const active = state.feedCategory === cat.key;
-      return `
-      <button
-        type="button"
-        class="feed-category-chip ${active ? "active" : ""}"
-        data-feed-category="${cat.key}"
-        aria-pressed="${active ? "true" : "false"}"
-      >
-        <span class="feed-category-icon">${cat.icon}</span>
-        <span>${cat.name}</span>
-      </button>
-    `;
-    })
-    .join("");
+  row.innerHTML = categories.map((cat) => {
+    const active = state.filters.category === cat.key || state.feedCategory === cat.key;
+    return `<button type="button" class="feed-category-chip ${active ? "active" : ""}" data-feed-category="${cat.key}" aria-pressed="${active ? "true" : "false"}"><span class="feed-category-icon">${cat.icon}</span><span>${cat.name}</span></button>`;
+  }).join("");
   row.querySelectorAll("[data-feed-category]").forEach((button) => {
-    button.addEventListener("click", () =>
-      setFeedCategory(button.getAttribute("data-feed-category"), button),
-    );
+    button.addEventListener("click", () => setFeedCategory(button.getAttribute("data-feed-category"), button));
   });
 }
 
 function syncFeedCategoryButtons() {
   document.querySelectorAll("[data-feed-category]").forEach((button) => {
-    const isActive = button.getAttribute("data-feed-category") === state.feedCategory;
+    const isActive = button.getAttribute("data-feed-category") === state.filters.category;
     button.classList.toggle("active", isActive);
     button.setAttribute("aria-pressed", isActive ? "true" : "false");
   });
 }
 
+function hasUnifiedFilterApplied(params) {
+  return Object.entries(params).some(([key, value]) => key !== "deal_type" && String(value || "").trim() !== "") || params.deal_type !== "feed";
+}
+
 export async function loadFeed() {
   if (!authGuard()) return;
   notify("feedNotice", "", "");
-  const search = qs("feedSearch").value.trim();
+  syncFiltersFromSearch("feedSearch");
+  syncSearchInputsFromFilters();
   const feed = qs("feedList");
   renderFeedCategoryRow();
   syncFeedFilterButtons();
   syncFeedCategoryButtons();
   renderFeedSkeleton(feed);
 
-  const params = { search };
-  if (state.feedFilter === "swap") params.deal_type = "swap";
-  if (state.feedFilter === "both") params.deal_type = "both";
-  if (state.feedFilter === "all") params.deal_type = "feed";
-  if (state.feedCategory !== "all") params.category = state.feedCategory;
-
-  const hasFilterApplied =
-    Boolean(search) || state.feedFilter !== "all" || state.feedCategory !== "all";
+  const params = buildItemQueryParams("feed");
+  const hasFilterApplied = hasUnifiedFilterApplied(params);
 
   try {
     await loadSavedListings();
-
-    // Use the smart feed endpoint when browsing without filters;
-    // use filtered list endpoint when user has applied search/category/type.
-    const response = hasFilterApplied
-      ? await items.list(params)
-      : await items.feed();
-
-    let list = (Array.isArray(response?.items) ? response.items : [])
-      .filter((i) => i?.dealType !== "buy")
-      .map(normalizeFeedItem);
-
-    if (list.length) {
-      feed.innerHTML = list.map(feedCardHtml).join("");
-    } else {
-      feed.innerHTML = emptyFeedStateHtml();
-    }
+    const response = hasFilterApplied ? await items.list(params) : await items.feed();
+    let list = (Array.isArray(response?.items) ? response.items : []).filter((i) => i?.dealType !== "buy").map(normalizeFeedItem);
+    feed.innerHTML = list.length ? list.map(feedCardHtml).join("") : emptyFeedStateHtml();
     bindCardActions(feed);
   } catch (e) {
     const message = String(e?.message || e);

--- a/artifacts/web-app/src/ui/filters.js
+++ b/artifacts/web-app/src/ui/filters.js
@@ -1,0 +1,193 @@
+import { state, categories, distanceOptionsKm } from "../state.js";
+
+function inputValue(id) {
+  const el = document.getElementById(id);
+  return el && "value" in el ? String(el.value || "") : "";
+}
+
+function checked(id) {
+  const el = document.getElementById(id);
+  return el instanceof HTMLInputElement ? Boolean(el.checked) : false;
+}
+
+function ensureFilterStyles() {
+  if (document.getElementById("unifiedFilterStyles")) return;
+  const style = document.createElement("style");
+  style.id = "unifiedFilterStyles";
+  style.textContent = `
+    .filter-sheet{position:fixed;inset:0;z-index:60;pointer-events:none}
+    .filter-sheet.open{pointer-events:auto}
+    .filter-backdrop{position:absolute;inset:0;background:rgba(0,0,0,.32);opacity:0;transition:.18s ease}
+    .filter-sheet.open .filter-backdrop{opacity:1}
+    .filter-panel{position:absolute;left:50%;bottom:0;transform:translateX(-50%) translateY(104%);width:100%;max-width:var(--maxw,430px);max-height:88vh;overflow:auto;background:var(--bg,#f7f5f1);border-radius:28px 28px 0 0;padding:10px 16px calc(20px + env(safe-area-inset-bottom));box-shadow:0 -18px 40px rgba(0,0,0,.18);transition:.24s ease}
+    .filter-sheet.open .filter-panel{transform:translateX(-50%) translateY(0)}
+    .filter-head{display:flex;align-items:center;justify-content:space-between;margin:4px 0 12px}.filter-head h3{margin:0;font-size:22px;font-weight:900;letter-spacing:-.04em}
+    .field-label{display:block;margin:12px 0 6px;font-size:12px;font-weight:900;color:var(--muted,#756d63);letter-spacing:.04em;text-transform:uppercase}
+    .input{width:100%;min-height:46px;border:1px solid var(--line,rgba(0,0,0,.08));border-radius:15px;background:var(--card,#fff);padding:0 13px;color:var(--text,#171614);outline:none;box-shadow:0 6px 16px rgba(0,0,0,.04)}
+    textarea.input{padding:12px 13px;line-height:1.45;resize:vertical}.filter-grid-2{display:grid;grid-template-columns:1fr 1fr;gap:10px}.filter-checks{display:flex;flex-direction:column;gap:8px;margin:14px 0}.filter-checks label{display:flex;align-items:center;gap:10px;background:var(--card,#fff);border-radius:15px;padding:11px 12px;font-size:13px;font-weight:800;box-shadow:0 6px 16px rgba(0,0,0,.04)}
+    .wanted-tags{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}.wanted-tag{border:none;border-radius:999px;background:var(--brand-soft,rgba(63,109,246,.12));color:var(--brand,#3f6df6);padding:7px 10px;font-size:12px;font-weight:900;cursor:pointer}.wanted-tag:active{transform:scale(.97)}
+  `;
+  document.head.appendChild(style);
+}
+
+export function syncSearchInputsFromFilters() {
+  const query = state.filters.query || "";
+  ["feedSearch", "shopSearch"].forEach((id) => {
+    const el = document.getElementById(id);
+    if (el && "value" in el && el.value !== query) el.value = query;
+  });
+}
+
+export function syncFiltersFromSearch(sourceId) {
+  const value = inputValue(sourceId).trim();
+  state.filters.query = value;
+  syncSearchInputsFromFilters();
+}
+
+export function buildItemQueryParams(context = "shop") {
+  const filters = state.filters || {};
+  const params = { search: filters.query || "" };
+  const deal = filters.dealType && filters.dealType !== "all" ? filters.dealType : context === "feed" ? "feed" : "";
+  if (deal) params.deal_type = deal;
+  if (filters.category && filters.category !== "all") params.category = filters.category;
+  if (String(filters.priceMin || "").trim() !== "") params.price_min = String(filters.priceMin).trim();
+  if (String(filters.priceMax || "").trim() !== "") params.price_max = String(filters.priceMax).trim();
+  if (filters.openToOffers) params.open_to_offers = "1";
+  if (filters.wantedTag) params.wanted_tag = filters.wantedTag;
+  if (filters.followingOnly) params.following_only = "1";
+  if (filters.nearbyKm) params.radius_km = String(filters.nearbyKm);
+  if (filters.fastResponder) params.fast_responder = "1";
+  if (filters.topUser) params.top_user = "1";
+  if (filters.hasRequests) params.has_requests = "1";
+  return params;
+}
+
+export function applyWantedTagFilter(tag) {
+  state.filters.query = tag;
+  state.filters.wantedTag = tag;
+  syncSearchInputsFromFilters();
+}
+
+export function ensureFilterSheet() {
+  ensureFilterStyles();
+  let sheet = document.getElementById("unifiedFilterSheet");
+  if (sheet) return sheet;
+  sheet = document.createElement("div");
+  sheet.id = "unifiedFilterSheet";
+  sheet.className = "filter-sheet";
+  sheet.innerHTML = `
+    <div class="filter-backdrop" data-filter-close="1"></div>
+    <section class="filter-panel" role="dialog" aria-modal="true" aria-label="ตัวกรองสินค้า">
+      <div class="sheet-handle"></div>
+      <div class="filter-head"><h3>ตัวกรอง</h3><button type="button" class="ghost-icon" data-filter-close="1">×</button></div>
+      <label class="field-label">ค้นหา</label>
+      <input id="filterQuery" class="input" placeholder="ค้นหาสินค้า / สิ่งที่อยากได้" />
+      <div class="filter-grid-2">
+        <div><label class="field-label">ราคาต่ำสุด</label><input id="filterPriceMin" class="input" inputmode="numeric" placeholder="0" /></div>
+        <div><label class="field-label">ราคาสูงสุด</label><input id="filterPriceMax" class="input" inputmode="numeric" placeholder="5000" /></div>
+      </div>
+      <label class="field-label">ระยะใกล้เคียง</label>
+      <select id="filterNearbyKm" class="input"><option value="">ไม่จำกัด</option>${distanceOptionsKm.map((km) => `<option value="${km}">${km} กม.</option>`).join("")}</select>
+      <label class="field-label">หมวดหมู่สินค้า</label>
+      <select id="filterCategory" class="input">${categories.map((cat) => `<option value="${cat.key}">${cat.icon} ${cat.name}</option>`).join("")}</select>
+      <label class="field-label">ประเภทดีล</label>
+      <select id="filterDealType" class="input"><option value="all">ทั้งหมด</option><option value="swap">แลก</option><option value="buy">ขาย</option><option value="both">ขายหรือแลก</option></select>
+      <div class="filter-checks">
+        <label><input type="checkbox" id="filterOpenToOffers" /> เปิดกว้างทุกข้อเสนอ</label>
+        <label><input type="checkbox" id="filterFollowingOnly" /> คนที่กำลัง follow</label>
+        <label><input type="checkbox" id="filterFastResponder" /> ตอบไว</label>
+        <label><input type="checkbox" id="filterTopUser" /> ผู้ใช้งานดีเด่น</label>
+        <label><input type="checkbox" id="filterHasRequests" /> มีคนรอแลก / มีข้อเสนอ</label>
+      </div>
+      <div class="btn-row"><button type="button" class="soft-btn" data-filter-reset="1">รีเซ็ต</button><button type="button" class="primary-btn" data-filter-apply="1">ใช้ตัวกรอง</button></div>
+      <p class="sub">ตัวกรองใกล้เคียง/ตอบไว/ผู้ใช้งานดีเด่นจะส่งค่าไป API เมื่อ backend รองรับ และไม่ทำให้ search เดิมพัง</p>
+    </section>
+  `;
+  document.body.appendChild(sheet);
+  sheet.addEventListener("click", async (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    if (target.closest("[data-filter-close]")) closeFilterSheet();
+    if (target.closest("[data-filter-reset]")) {
+      resetUnifiedFilters();
+      populateFilterForm();
+    }
+    if (target.closest("[data-filter-apply]")) {
+      readFilterForm();
+      closeFilterSheet();
+      const { loadFeed } = await import("./feed.js");
+      const { loadShop } = await import("./shop.js");
+      await Promise.allSettled([loadFeed(), loadShop()]);
+    }
+  });
+  return sheet;
+}
+
+function populateFilterForm() {
+  const f = state.filters;
+  const setVal = (id, val) => {
+    const el = document.getElementById(id);
+    if (el && "value" in el) el.value = val || "";
+  };
+  const setChecked = (id, val) => {
+    const el = document.getElementById(id);
+    if (el instanceof HTMLInputElement) el.checked = Boolean(val);
+  };
+  setVal("filterQuery", f.query);
+  setVal("filterPriceMin", f.priceMin);
+  setVal("filterPriceMax", f.priceMax);
+  setVal("filterNearbyKm", f.nearbyKm);
+  setVal("filterCategory", f.category || "all");
+  setVal("filterDealType", f.dealType || "all");
+  setChecked("filterOpenToOffers", f.openToOffers);
+  setChecked("filterFollowingOnly", f.followingOnly);
+  setChecked("filterFastResponder", f.fastResponder);
+  setChecked("filterTopUser", f.topUser);
+  setChecked("filterHasRequests", f.hasRequests);
+}
+
+function readFilterForm() {
+  state.filters.query = inputValue("filterQuery").trim();
+  state.filters.priceMin = inputValue("filterPriceMin").trim();
+  state.filters.priceMax = inputValue("filterPriceMax").trim();
+  state.filters.nearbyKm = inputValue("filterNearbyKm");
+  state.filters.category = inputValue("filterCategory") || "all";
+  state.filters.dealType = inputValue("filterDealType") || "all";
+  state.filters.openToOffers = checked("filterOpenToOffers");
+  state.filters.followingOnly = checked("filterFollowingOnly");
+  state.filters.fastResponder = checked("filterFastResponder");
+  state.filters.topUser = checked("filterTopUser");
+  state.filters.hasRequests = checked("filterHasRequests");
+  syncSearchInputsFromFilters();
+}
+
+export function openFilterSheet() {
+  const sheet = ensureFilterSheet();
+  populateFilterForm();
+  sheet.classList.add("open");
+  document.body.classList.add("modal-open");
+}
+
+export function closeFilterSheet() {
+  const sheet = document.getElementById("unifiedFilterSheet");
+  if (sheet) sheet.classList.remove("open");
+  document.body.classList.remove("modal-open");
+}
+
+export function resetUnifiedFilters() {
+  state.filters = {
+    query: "",
+    priceMin: "",
+    priceMax: "",
+    followingOnly: false,
+    nearbyKm: "",
+    fastResponder: false,
+    topUser: false,
+    hasRequests: false,
+    category: "all",
+    dealType: "all",
+    openToOffers: false,
+    wantedTag: "",
+  };
+  syncSearchInputsFromFilters();
+}

--- a/artifacts/web-app/src/ui/refresh.js
+++ b/artifacts/web-app/src/ui/refresh.js
@@ -1,0 +1,13 @@
+import { loadFeed } from "./feed.js";
+import { loadShop } from "./shop.js";
+import { loadInbox } from "./inbox.js";
+import { loadProfile } from "./profile.js";
+
+export async function refreshAllData({ stayOnScreen = true } = {}) {
+  const tasks = [loadFeed(), loadShop(), loadInbox(), loadProfile()];
+  const results = await Promise.allSettled(tasks);
+  if (!stayOnScreen) {
+    return results;
+  }
+  return results;
+}

--- a/artifacts/web-app/src/ui/shop.js
+++ b/artifacts/web-app/src/ui/shop.js
@@ -3,38 +3,45 @@ import { state, categories } from "../state.js";
 import { items } from "../api.js";
 import { authGuard } from "./nav.js";
 import { productCardHtml, bindCardActions } from "./cards.js";
+import { buildItemQueryParams, syncFiltersFromSearch, syncSearchInputsFromFilters } from "./filters.js";
 
 export { productCardHtml };
 
+function normalizeShopItem(item) {
+  return {
+    ...item,
+    wantedTags: Array.isArray(item?.wantedTags) ? item.wantedTags : [],
+    imageUrls: Array.isArray(item?.imageUrls) ? item.imageUrls : undefined,
+    image_urls: Array.isArray(item?.image_urls) ? item.image_urls : undefined,
+    priceCash: Number(item?.priceCash || 0),
+    priceCredit: Number(item?.priceCredit || 0),
+  };
+}
+
 export function renderCategories() {
   const row = qs("categoryRow");
-  row.innerHTML = categories
-    .map(
-      (cat) => `
-    <div class="category-card ${state.currentCategory === cat.key ? "active" : ""}" data-cat-key="${cat.key}">
+  if (!row) return;
+  row.innerHTML = categories.map((cat) => `
+    <div class="category-card ${state.filters.category === cat.key ? "active" : ""}" data-cat-key="${cat.key}">
       <div class="category-icon">${cat.icon}</div>
       <div class="category-name">${cat.name}</div>
-    </div>`,
-    )
-    .join("");
+    </div>`).join("");
   row.querySelectorAll("[data-cat-key]").forEach((el) => {
-    el.addEventListener("click", () =>
-      setCategory(el.getAttribute("data-cat-key")),
-    );
+    el.addEventListener("click", () => setCategory(el.getAttribute("data-cat-key")));
   });
 }
 
 export function setCategory(key) {
-  state.currentCategory = key;
+  state.currentCategory = key || "all";
+  state.filters.category = key || "all";
   renderCategories();
   loadShop();
 }
 
 export function setShopFilter(filter, btn) {
   state.shopFilter = filter;
-  document
-    .querySelectorAll("[data-shop-filter]")
-    .forEach((x) => x.classList.remove("active"));
+  state.filters.dealType = filter === "all" ? "all" : filter;
+  document.querySelectorAll("[data-shop-filter]").forEach((x) => x.classList.remove("active"));
   if (btn) btn.classList.add("active");
   loadShop();
 }
@@ -42,17 +49,14 @@ export function setShopFilter(filter, btn) {
 export async function loadShop() {
   if (!authGuard()) return;
   notify("shopNotice", "", "");
-  const search = qs("shopSearch").value.trim();
-  const params = { search };
-  if (state.shopFilter === "swap") params.deal_type = "swap";
-  if (state.shopFilter === "buy") params.deal_type = "buy";
-  if (state.currentCategory !== "all") params.category = state.currentCategory;
+  syncFiltersFromSearch("shopSearch");
+  syncSearchInputsFromFilters();
+  const params = buildItemQueryParams("shop");
   try {
     const { items: list } = await items.list(params);
     const grid = qs("shopGrid");
-    grid.innerHTML = list.length
-      ? list.map(productCardHtml).join("")
-      : `<div class="empty" style="grid-column:1/-1">ยังไม่มีสินค้า</div>`;
+    const normalized = (Array.isArray(list) ? list : []).map(normalizeShopItem);
+    grid.innerHTML = normalized.length ? normalized.map(productCardHtml).join("") : `<div class="empty" style="grid-column:1/-1">ยังไม่มีสินค้า</div>`;
     bindCardActions(grid);
   } catch (e) {
     notify("shopNotice", "error", String(e?.message || e));

--- a/lib/db/src/schema/items.ts
+++ b/lib/db/src/schema/items.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm";
 import {
+  boolean,
   customType,
   integer,
   pgEnum,
@@ -40,6 +41,8 @@ export const itemsTable = pgTable("items", {
   priceCash: integer("price_cash").notNull().default(0),
   priceCredit: integer("price_credit").notNull().default(0),
   wantedText: text("wanted_text"),
+  wantedTags: text("wanted_tags").array().notNull().default(sql`'{}'::text[]`),
+  openToOffers: boolean("open_to_offers").notNull().default(true),
   status: itemStatusEnum("status").notNull().default("active"),
   locationLabel: varchar("location_label").notNull().default("Bangkok"),
   imageEmoji: varchar("image_emoji").notNull().default("📦"),


### PR DESCRIPTION
## Summary

Continues from merged PR #69 and implements the QXwap product UX, filters, refresh, and offer-flow fixes requested in Issues #76/#77.

Currently pushed in this PR:
- Adds backward-compatible item metadata columns for `wantedTags` and `openToOffers`.
- Adds safe startup migrations for `wanted_tags`, `open_to_offers`, and search-vector support without removing existing image columns.
- Preserves existing product image fields and upload/rendering compatibility: `image_urls`, `imageUrls`, `imageUrl`, and related image rendering paths.
- Extends item listing filters for price min/max, open-to-offers, and wanted-tag queries.
- Fixes blank `price_min` / `price_max` so empty filter inputs are ignored instead of treated as `0`.
- Restores strict value validation when `openToOffers=false`:
  - `buy` requires positive cash price.
  - `swap` requires credit or wanted text/tags.
  - `both` requires at least one of cash, credit, wanted text, or wanted tags.
- Allows `openToOffers=true` listings to have optional price/wanted data.
- Allows message-only/cash/credit offers so accounts with no posted products can still send offers.
- Adds `refreshAllData()` and wires refresh after login/signup/session, product creation, offer submission, and delete actions.
- Adds item-detail loading by item id via `GET /items/:id`.
- Fixes Feed/Shop card click handling so cards can open detail by id.
- Adds owner-only actions in detail: owners see Edit/Delete, visitors see Xwap.
- Adds wanted tags display and clickable wanted-tag search/filter.
- Adds Add Product enhancements: deal type icon cards, optional price, open-to-offers checkbox, wanted tags, and improved cash/credit placeholders.
- Adds unified Feed/Shop filter state and a filter sheet with search, price, following, nearby distance, fast responder, top user, category, deal type, has requests, open-to-offers, and wanted tag filters.

## Current status

- Rebased onto latest `main`.
- PR metadata now reports `mergeable: true`.
- Current head: `d6a97c466ef7102e7bc25701156e92f366dc131e`.
- GitHub Actions CI run `25046223601` completed successfully.

## CI checks passed

GitHub Actions job `Build & Typecheck` passed these steps:
- Install dependencies
- Build lib/db
- Build lib/api-zod
- Typecheck api-server
- Run unit tests
- Build api-server
- Check build output
- Typecheck web-app
- Build web-app

## Preservation rule

Existing product images must keep working. This PR does not remove or rename the existing image fields. Image upload still uses the existing upload flow and `imageUrls` payload.

## Remaining before merge

Manual browser verification is still required for real image/product flows and injected UI:
- Existing image products still show images in Feed, Shop, and detail.
- Creating a product with images still works.
- Login shows products without browser refresh.
- Posting a product refreshes automatically and keeps expected navigation.
- Non-owner does not see Edit/Delete.
- Owner still sees Edit/Delete for own items.
- Feed and Shop cards open detail.
- Account with no products can make message/cash/credit offer.
- Add Product deal type icon cards work.
- Optional price/open-to-all-offers works.
- Wanted tags show and clicking a tag searches/filters.
- Search + filter works together in Shop and Feed.

Refs #76
Refs #77