### PR TITLE
Add Expo Go preview test shell

### DIFF
--- a/.github/workflows/expo-go-preview.yml
+++ b/.github/workflows/expo-go-preview.yml
@@ -1,0 +1,38 @@
+name: Expo Go Preview
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/expo-go/**"
+      - ".github/workflows/expo-go-preview.yml"
+  push:
+    branches: ["feature/**"]
+    paths:
+      - "apps/expo-go/**"
+      - ".github/workflows/expo-go-preview.yml"
+
+jobs:
+  expo-go-preview:
+    name: Validate Expo Go preview
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/expo-go
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: apps/expo-go/package.json
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Verify Expo preview config
+        run: npm run check
+
+      - name: Run Expo doctor
+        run: npx expo-doctor

--- a/apps/expo-go/App.js
+++ b/apps/expo-go/App.js
@@ -1,0 +1,276 @@
+import Constants from 'expo-constants';
+import React, { useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Linking,
+  Platform,
+  Pressable,
+  SafeAreaView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { WebView } from 'react-native-webview';
+
+const fallbackUrl = 'https://aswer18400.github.io/QXwap/';
+
+function normalizeUrl(value) {
+  const trimmed = String(value || '').trim();
+  if (!trimmed) return fallbackUrl;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return `https://${trimmed}`;
+}
+
+export default function App() {
+  const webViewRef = useRef(null);
+  const defaultUrl = Constants.expoConfig?.extra?.defaultWebUrl || fallbackUrl;
+  const [inputUrl, setInputUrl] = useState(defaultUrl);
+  const [url, setUrl] = useState(normalizeUrl(defaultUrl));
+  const [isLoading, setIsLoading] = useState(true);
+  const [canGoBack, setCanGoBack] = useState(false);
+  const [lastError, setLastError] = useState('');
+
+  const source = useMemo(() => ({ uri: url }), [url]);
+
+  const openUrl = () => {
+    const next = normalizeUrl(inputUrl);
+    setLastError('');
+    setIsLoading(true);
+    setUrl(next);
+  };
+
+  const reload = () => {
+    setLastError('');
+    webViewRef.current?.reload();
+  };
+
+  const goBack = () => {
+    if (canGoBack) {
+      webViewRef.current?.goBack();
+    }
+  };
+
+  const openExternal = async () => {
+    const supported = await Linking.canOpenURL(url);
+    if (!supported) {
+      Alert.alert('เปิดลิงก์ไม่ได้', url);
+      return;
+    }
+    await Linking.openURL(url);
+  };
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <StatusBar barStyle={Platform.OS === 'ios' ? 'dark-content' : 'light-content'} />
+      <View style={styles.header}>
+        <View style={styles.titleRow}>
+          <Text style={styles.title}>QXwap Expo Go</Text>
+          <Text style={styles.badge}>Preview</Text>
+        </View>
+        <Text style={styles.subtitle}>ใช้ทดสอบเว็บ QXwap บนมือถือผ่าน Expo Go</Text>
+        <View style={styles.urlRow}>
+          <TextInput
+            value={inputUrl}
+            onChangeText={setInputUrl}
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="url"
+            placeholder="https://..."
+            style={styles.input}
+            returnKeyType="go"
+            onSubmitEditing={openUrl}
+          />
+          <Pressable style={styles.primaryButton} onPress={openUrl}>
+            <Text style={styles.primaryButtonText}>เปิด</Text>
+          </Pressable>
+        </View>
+        <View style={styles.actionRow}>
+          <Pressable style={[styles.smallButton, !canGoBack && styles.disabledButton]} onPress={goBack} disabled={!canGoBack}>
+            <Text style={styles.smallButtonText}>ย้อนกลับ</Text>
+          </Pressable>
+          <Pressable style={styles.smallButton} onPress={reload}>
+            <Text style={styles.smallButtonText}>รีโหลด</Text>
+          </Pressable>
+          <Pressable style={styles.smallButton} onPress={openExternal}>
+            <Text style={styles.smallButtonText}>เปิด Browser</Text>
+          </Pressable>
+        </View>
+      </View>
+
+      <View style={styles.webWrap}>
+        <WebView
+          ref={webViewRef}
+          source={source}
+          style={styles.webview}
+          sharedCookiesEnabled
+          thirdPartyCookiesEnabled
+          javaScriptEnabled
+          domStorageEnabled
+          allowsBackForwardNavigationGestures
+          pullToRefreshEnabled
+          onLoadStart={() => {
+            setIsLoading(true);
+            setLastError('');
+          }}
+          onLoadEnd={() => setIsLoading(false)}
+          onNavigationStateChange={(navState) => {
+            setCanGoBack(navState.canGoBack);
+            if (navState.url) {
+              setUrl(navState.url);
+              setInputUrl(navState.url);
+            }
+          }}
+          onError={(event) => {
+            const message = event.nativeEvent.description || 'โหลดเว็บไม่สำเร็จ';
+            setLastError(message);
+            setIsLoading(false);
+          }}
+        />
+        {isLoading ? (
+          <View style={styles.loadingOverlay} pointerEvents="none">
+            <ActivityIndicator size="large" />
+            <Text style={styles.loadingText}>กำลังโหลด...</Text>
+          </View>
+        ) : null}
+        {lastError ? (
+          <View style={styles.errorBox}>
+            <Text style={styles.errorTitle}>โหลดไม่สำเร็จ</Text>
+            <Text style={styles.errorText}>{lastError}</Text>
+            <Text style={styles.errorHint}>ตรวจว่า API/Pages เปิดอยู่ และมือถืออยู่เครือข่ายที่เข้าถึง URL นี้ได้</Text>
+          </View>
+        ) : null}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: '#111827',
+  },
+  header: {
+    backgroundColor: '#111827',
+    paddingHorizontal: 12,
+    paddingTop: 10,
+    paddingBottom: 10,
+    gap: 8,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  title: {
+    color: '#ffffff',
+    fontSize: 18,
+    fontWeight: '800',
+  },
+  badge: {
+    color: '#c7d2fe',
+    backgroundColor: '#3730a3',
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 999,
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  subtitle: {
+    color: '#cbd5e1',
+    fontSize: 12,
+  },
+  urlRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  input: {
+    flex: 1,
+    minHeight: 42,
+    backgroundColor: '#ffffff',
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    color: '#111827',
+  },
+  primaryButton: {
+    minHeight: 42,
+    paddingHorizontal: 16,
+    borderRadius: 12,
+    backgroundColor: '#4f46e5',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  primaryButtonText: {
+    color: '#ffffff',
+    fontWeight: '800',
+  },
+  actionRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  smallButton: {
+    flex: 1,
+    minHeight: 34,
+    borderRadius: 10,
+    backgroundColor: '#1f2937',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  disabledButton: {
+    opacity: 0.45,
+  },
+  smallButtonText: {
+    color: '#e5e7eb',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  webWrap: {
+    flex: 1,
+    backgroundColor: '#ffffff',
+  },
+  webview: {
+    flex: 1,
+  },
+  loadingOverlay: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(255,255,255,0.72)',
+  },
+  loadingText: {
+    marginTop: 10,
+    color: '#111827',
+    fontWeight: '700',
+  },
+  errorBox: {
+    position: 'absolute',
+    left: 16,
+    right: 16,
+    bottom: 20,
+    backgroundColor: '#fee2e2',
+    borderColor: '#ef4444',
+    borderWidth: 1,
+    borderRadius: 14,
+    padding: 12,
+  },
+  errorTitle: {
+    color: '#991b1b',
+    fontWeight: '900',
+    marginBottom: 4,
+  },
+  errorText: {
+    color: '#7f1d1d',
+    fontWeight: '700',
+  },
+  errorHint: {
+    color: '#7f1d1d',
+    fontSize: 12,
+    marginTop: 4,
+  },
+});

--- a/apps/expo-go/README.md
+++ b/apps/expo-go/README.md
@@ -1,0 +1,43 @@
+# QXwap Expo Go Preview
+
+This folder is a lightweight Expo Go wrapper for testing the deployed QXwap web app on a real iOS or Android device.
+
+It does not replace the main web app. It opens the deployed QXwap URL inside a React Native WebView so mobile behavior can be checked quickly in Expo Go.
+
+## Run on Expo Go
+
+```bash
+cd apps/expo-go
+npm install
+npm run check
+npm start
+```
+
+Then open the project from Expo Go.
+
+## What to test on device
+
+- Existing product images show in Feed, Shop, and detail.
+- Creating a product with images works.
+- Login shows products without browser refresh.
+- Posting a product refreshes automatically.
+- Non-owner does not see Edit/Delete.
+- Owner still sees Edit/Delete for own items.
+- Feed and Shop cards open detail.
+- An account with no products can make a message, cash, or credit offer.
+- Add Product deal type cards work.
+- Optional price and open-to-all-offers works.
+- Wanted tags show and clicking a tag searches or filters.
+- Search and filter work together in Shop and Feed.
+
+## Change target URL
+
+The default URL is in app.json under expo.extra.defaultWebUrl.
+
+You can also type another HTTPS URL into the input field inside the Expo Go app.
+
+## Notes
+
+- Use a deployed HTTPS URL for the best Expo Go result.
+- If testing a local backend, the phone must be able to reach that backend from the same network.
+- Cookies are enabled in the WebView so auth/session behavior can be tested.

--- a/apps/expo-go/app.json
+++ b/apps/expo-go/app.json
@@ -1,0 +1,19 @@
+{
+  "expo": {
+    "name": "QXwap Preview",
+    "slug": "qxwap-preview",
+    "version": "0.1.0",
+    "orientation": "portrait",
+    "scheme": "qxwap-preview",
+    "userInterfaceStyle": "automatic",
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "edgeToEdgeEnabled": true
+    },
+    "extra": {
+      "defaultWebUrl": "https://aswer18400.github.io/QXwap/"
+    }
+  }
+}

--- a/apps/expo-go/app.json
+++ b/apps/expo-go/app.json
@@ -9,9 +9,7 @@
     "ios": {
       "supportsTablet": true
     },
-    "android": {
-      "edgeToEdgeEnabled": true
-    },
+    "android": {},
     "extra": {
       "defaultWebUrl": "https://aswer18400.github.io/QXwap/"
     }

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "qxwap-expo-go-preview",
+  "version": "0.0.0",
+  "private": true,
+  "main": "expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "doctor": "expo doctor",
+    "check": "node ./scripts/verify-config.mjs",
+    "test:expo-go": "npm run check && expo doctor"
+  },
+  "dependencies": {
+    "expo": "~55.0.0",
+    "expo-constants": "~19.0.8",
+    "react": "19.2.0",
+    "react-native": "0.83.0",
+    "react-native-webview": "13.16.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.26.0"
+  }
+}

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "expo": "~55.0.0",
-    "expo-constants": "~19.0.8",
+    "expo-constants": "~55.0.7",
     "react": "19.2.0",
     "react-native": "0.83.0",
     "react-native-webview": "13.16.0"

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -13,7 +13,7 @@
     "expo": "~55.0.0",
     "expo-constants": "~55.0.7",
     "react": "19.2.0",
-    "react-native": "0.83.0",
+    "react-native": "0.83.6",
     "react-native-webview": "13.16.0"
   },
   "devDependencies": {

--- a/apps/expo-go/scripts/verify-config.mjs
+++ b/apps/expo-go/scripts/verify-config.mjs
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const root = process.cwd();
+const requiredFiles = ['package.json', 'app.json', 'App.js'];
+const missing = requiredFiles.filter((file) => !fs.existsSync(path.join(root, file)));
+
+if (missing.length) {
+  console.error(`Missing required Expo files: ${missing.join(', ')}`);
+  process.exit(1);
+}
+
+const packageJson = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+const appJson = JSON.parse(fs.readFileSync(path.join(root, 'app.json'), 'utf8'));
+
+const dependencies = packageJson.dependencies || {};
+const requiredDeps = ['expo', 'react', 'react-native', 'react-native-webview', 'expo-constants'];
+const missingDeps = requiredDeps.filter((dep) => !dependencies[dep]);
+
+if (missingDeps.length) {
+  console.error(`Missing required Expo dependencies: ${missingDeps.join(', ')}`);
+  process.exit(1);
+}
+
+if (!appJson.expo?.name || !appJson.expo?.slug) {
+  console.error('app.json must define expo.name and expo.slug');
+  process.exit(1);
+}
+
+const defaultWebUrl = appJson.expo?.extra?.defaultWebUrl;
+if (!defaultWebUrl || !/^https?:\/\//i.test(defaultWebUrl)) {
+  console.error('app.json expo.extra.defaultWebUrl must be an absolute http(s) URL');
+  process.exit(1);
+}
+
+const appJs = fs.readFileSync(path.join(root, 'App.js'), 'utf8');
+for (const needle of ['WebView', 'sharedCookiesEnabled', 'thirdPartyCookiesEnabled', 'defaultWebUrl']) {
+  if (!appJs.includes(needle)) {
+    console.error(`App.js is missing expected Expo Go WebView marker: ${needle}`);
+    process.exit(1);
+  }
+}
+
+console.log('Expo Go preview config OK');


### PR DESCRIPTION
## Summary

Adds a lightweight Expo Go preview app under `apps/expo-go` so QXwap can be tested on a real iOS/Android device through Expo Go.

This does not replace the existing web app. It wraps the deployed QXwap web URL in a React Native WebView with cookies enabled so auth/session/product flows can be checked on mobile.

## What changed

- Added `apps/expo-go/package.json` with Expo, React Native, Expo Constants, and React Native WebView dependencies.
- Added `apps/expo-go/app.json` with default QXwap Pages URL.
- Added `apps/expo-go/App.js` with:
  - URL input
  - WebView preview
  - reload/back/open-browser actions
  - loading and error states
  - shared/third-party cookies enabled for login session testing
- Added `apps/expo-go/scripts/verify-config.mjs` to validate Expo preview config.
- Added `apps/expo-go/README.md` with Expo Go test instructions.
- Added `.github/workflows/expo-go-preview.yml` to install and validate the Expo preview app.

## Run locally

```bash
cd apps/expo-go
npm install
npm run check
npm start
```

Then open the project in Expo Go.

## Device checklist

- Existing product images show in Feed, Shop, and detail.
- Creating a product with images works.
- Login shows products without browser refresh.
- Posting a product refreshes automatically.
- Non-owner does not see Edit/Delete.
- Owner still sees Edit/Delete for own items.
- Feed and Shop cards open detail.
- An account with no products can make a message, cash, or credit offer.
- Add Product deal type cards work.
- Optional price and open-to-all-offers works.
- Wanted tags show and clicking a tag searches or filters.
- Search and filter work together in Shop and Feed.