### PR TITLE
Add agent-ready repository indexing

### DIFF
--- a/.github/workflows/agent-index.yml
+++ b/.github/workflows/agent-index.yml
@@ -1,0 +1,48 @@
+name: Agent Repository Index
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  index:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate repository index
+        run: pnpm agent:index
+
+      - name: Upload index artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qxwap-agent-index
+          path: docs/agent-index/
+
+      - name: Commit generated index on main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Update agent repository index
+          file_pattern: docs/agent-index/repository-index.json docs/agent-index/repository-index.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# QXwap Agent Instructions
+
+Repository: `aswer18400/QXwap`
+Default branch: `main`
+
+## Agent operating mode
+
+1. Start read-only: inspect repository structure, package files, deployment files, schema files, and key app entry points before editing.
+2. Use `docs/agent-index/README.md` and any generated files in `docs/agent-index/` as the first context source.
+3. Never commit secrets, private keys, service-role keys, `.env`, tokens, or credentials.
+4. Prefer a new branch for every change. Do not push directly to `main` unless explicitly requested.
+5. Before making code changes, identify the exact files affected and explain why they are the right files.
+6. After changes, run available checks: `pnpm install`, `pnpm run typecheck`, `pnpm run build`, or the closest project-specific command.
+7. Open a pull request with a clear summary, testing notes, and risk notes.
+
+## Project signals
+
+Known areas from repository search:
+
+- Web app artifacts: `artifacts/web-app/`
+- API server artifacts: `artifacts/api-server/`
+- Expo app: `apps/expo-go/`
+- Supabase schema assets: `attached_assets/supabase_schema_*.sql`
+- Render deployment config: `render.yaml`
+- Existing build/index script: `scripts/build-index.mjs`
+
+## Useful commands
+
+```bash
+pnpm install
+pnpm run typecheck
+pnpm run build
+pnpm agent:index
+```
+
+If `pnpm agent:index` is not available yet, use repository search and manually create a text analysis in `docs/agent-index/`.

--- a/docs/agent-index/README.md
+++ b/docs/agent-index/README.md
@@ -1,0 +1,16 @@
+# QXwap Agent Index
+
+This folder is reserved for generated repository index files.
+
+Run:
+
+```bash
+pnpm agent:index
+```
+
+Generated files:
+
+- `docs/agent-index/repository-index.json`
+- `docs/agent-index/repository-index.md`
+
+Agents should read `AGENTS.md` first, then this index, then the files referenced by the index.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "preinstall": "sh -c 'rm -f package-lock.json yarn.lock; case \"$npm_config_user_agent\" in pnpm/*) ;; *) echo \"Use pnpm instead\" >&2; exit 1 ;; esac'",
     "build": "pnpm run typecheck && pnpm -r --if-present run build",
     "preflight:pr": "bash ./scripts/preflight-pr.sh",
+    "agent:index": "pnpm --filter @workspace/scripts repo-index",
     "typecheck:libs": "tsc --build",
     "typecheck": "pnpm run typecheck:libs && pnpm -r --filter \"./artifacts/**\" --filter \"./scripts\" --if-present run typecheck"
   },

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "hello": "tsx ./src/hello.ts",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "repo-index": "node ./repo-index.mjs",
+    "typecheck": "tsc -p tsconfig.json --noEmit && node --check ./repo-index.mjs",
     "verify:runtime-config": "tsx ./src/verify-runtime-config.ts"
   },
   "devDependencies": {

--- a/scripts/repo-index.mjs
+++ b/scripts/repo-index.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+const root = process.cwd();
+const outDir = path.join(root, 'docs', 'agent-index');
+const ignoreDirs = new Set(['.git', 'node_modules', 'dist', 'build', 'coverage', '.cache', '.local', '.expo', '.next', 'docs/agent-index']);
+const textExtensions = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.json', '.md', '.html', '.css', '.sql', '.yml', '.yaml', '.toml', '.txt', '.sh']);
+
+function relative(file) {
+  return path.relative(root, file).replaceAll(path.sep, '/');
+}
+
+function shouldSkip(relativePath) {
+  return relativePath.split('/').some((part) => ignoreDirs.has(part));
+}
+
+function isText(file) {
+  const base = path.basename(file);
+  const ext = path.extname(file).toLowerCase();
+  return textExtensions.has(ext) || base === 'Dockerfile' || base === '.gitignore';
+}
+
+function walk(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const full = path.join(dir, entry.name);
+    const rel = relative(full);
+    if (entry.isDirectory()) {
+      if (!shouldSkip(rel)) walk(full, files);
+      continue;
+    }
+    if (!entry.isFile() || !isText(full)) continue;
+    const stat = fs.statSync(full);
+    if (stat.size > 1000000) continue;
+    files.push(full);
+  }
+  return files;
+}
+
+function matches(text, pattern) {
+  return [...new Set([...text.matchAll(pattern)].map((m) => m[1] || m[0]))].slice(0, 40);
+}
+
+function tags(file, text) {
+  const haystack = `${file}\n${text.slice(0, 5000)}`.toLowerCase();
+  const out = [];
+  if (/supabase|postgres|sql/.test(haystack)) out.push('database');
+  if (/express|router\.|app\.(get|post|put|delete)|api/.test(haystack)) out.push('api');
+  if (/react|jsx|tsx|vite|expo|react-native/.test(haystack)) out.push('frontend');
+  if (/auth|signin|signup|oauth/.test(haystack)) out.push('auth');
+  if (/render\.yaml|workflow|deploy/.test(haystack)) out.push('deployment');
+  return out;
+}
+
+function summarize(full) {
+  const file = relative(full);
+  const text = fs.readFileSync(full, 'utf8');
+  const lines = text.split(/\r?\n/);
+  return {
+    path: file,
+    bytes: Buffer.byteLength(text),
+    lines: lines.length,
+    sha256: crypto.createHash('sha256').update(text).digest('hex'),
+    tags: tags(file, text),
+    imports: matches(text, /import\s+(?:[^'\"]+\s+from\s+)?['\"]([^'\"]+)['\"]/g),
+    routes: matches(text, /(?:router|app)\.(?:get|post|put|patch|delete)\(['\"]([^'\"]+)['\"]/g),
+    env: matches(text, /process\.env\.([A-Z0-9_]+)/g),
+    preview: lines.filter((line) => line.trim()).slice(0, 6).join('\n').slice(0, 800)
+  };
+}
+
+const files = walk(root).map(summarize);
+const index = {
+  schema_version: 1,
+  generated_at: new Date().toISOString(),
+  repository: process.env.GITHUB_REPOSITORY || path.basename(root),
+  commit: process.env.GITHUB_SHA || null,
+  summary: {
+    files_indexed: files.length,
+    lines_indexed: files.reduce((sum, file) => sum + file.lines, 0),
+    bytes_indexed: files.reduce((sum, file) => sum + file.bytes, 0)
+  },
+  files
+};
+
+const markdown = `# QXwap Repository Index\n\nGenerated: ${index.generated_at}\n\n- Files indexed: ${index.summary.files_indexed}\n- Lines indexed: ${index.summary.lines_indexed}\n- Bytes indexed: ${index.summary.bytes_indexed}\n\n## Files\n\n${files.map((file) => `### ${file.path}\n- tags: ${file.tags.join(', ') || '-'}\n- lines: ${file.lines}\n- imports: ${file.imports.slice(0, 12).join(', ') || '-'}\n- routes: ${file.routes.join(', ') || '-'}\n- env: ${file.env.join(', ') || '-'}`).join('\n\n')}\n`;
+
+fs.mkdirSync(outDir, { recursive: true });
+fs.writeFileSync(path.join(outDir, 'repository-index.json'), `${JSON.stringify(index, null, 2)}\n`);
+fs.writeFileSync(path.join(outDir, 'repository-index.md'), markdown);
+console.log(`Indexed ${files.length} files into docs/agent-index/`);


### PR DESCRIPTION
## Summary

Adds agent collaboration and repository indexing support so external assistants can analyze QXwap with stable repo context.

## Changes

- Adds `AGENTS.md` with read-only-first agent instructions and known project areas.
- Adds `docs/agent-index/README.md` as the persistent index location.
- Adds `scripts/repo-index.mjs` to generate `repository-index.json` and `repository-index.md`.
- Adds `pnpm agent:index` at the workspace root.
- Adds a GitHub Actions workflow to generate/upload the index and update generated index files on pushes to `main`.

## Testing

Not run locally in this environment. The PR workflow should run `pnpm install --frozen-lockfile` and `pnpm agent:index`.

## Notes

This avoids committing secrets and keeps index generation deterministic inside the repository.