### PR TITLE
fix: CI health check failing — NODE_ENV=production missing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,12 +34,18 @@ jobs:
         run: npm test
 
       - name: Verify backend health (pglite, no external DB needed)
+        env:
+          NODE_ENV: production
+          DATABASE_URL: ./data/ci-db
+          SESSION_SECRET: ci-health-check-secret-32chars-ok
         run: |
+          mkdir -p ./data/ci-db
           node dist/boot.js &
           SERVER_PID=$!
-          sleep 5
-          curl -f http://localhost:3000/api/health || (kill $SERVER_PID; exit 1)
-          kill $SERVER_PID
+          sleep 8
+          curl -f http://localhost:3000/api/health \
+            && kill $SERVER_PID \
+            || (kill $SERVER_PID 2>/dev/null; exit 1)
 
   deploy-frontend:
     name: Deploy frontend to GitHub Pages


### PR DESCRIPTION
## Root cause

`api/boot.ts` only calls `serve()` when `env.isProduction === true`:

```typescript
if (env.isProduction) {
  const { serve } = await import("@hono/node-server");
  serve({ fetch: app.fetch, port: env.port }, ...);
}
```

The previous CI health check step ran `node dist/boot.js` without setting `NODE_ENV=production`, so the process exited immediately without binding to any port. The subsequent `curl localhost:3000/api/health` got "connection refused" and the step failed after ~40 s.

## Fix

Add `NODE_ENV=production` and a non-postgres `DATABASE_URL` (so PGlite is used instead of requiring a real DB) to the health check step env. Also raise the sleep from 5 s → 8 s to give PGlite time to initialise on first run.

```yaml
- name: Verify backend health (pglite, no external DB needed)
  env:
    NODE_ENV: production
    DATABASE_URL: ./data/ci-db
    SESSION_SECRET: ci-health-check-secret-32chars-ok
  run: |
    mkdir -p ./data/ci-db
    node dist/boot.js &
    ...
```

No application code changed — workflow only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YYZrwW4pt8aYW7S16Gsmth)_