### PR TITLE
fix: require Node 20 for Render build — Vite 7 needs Node>=20

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build && esbuild api/boot.ts --platform=node --bundle --format=esm --outdir=dist --external:@electric-sql/pglite --external:drizzle-orm --external:drizzle-orm/pglite --external:drizzle-orm/pg-core --external:drizzle-orm/node-postgres --external:pg --external:bcryptjs --external:uuid --external:superjson --external:hono --external:@hono/node-server --external:@trpc/server --external:@trpc/server/adapters/fetch --banner:js=\"import { createRequire } from 'module';const require = createRequire(import.meta.url);\"",

--- a/render.yaml
+++ b/render.yaml
@@ -12,6 +12,8 @@ services:
     startCommand: node dist/boot.js
     healthCheckPath: /api/health
     envVars:
+      - key: NODE_VERSION
+        value: "20"
       - key: NODE_ENV
         value: production
       - key: PORT


### PR DESCRIPTION
## Problem

Render free tier defaults to **Node 18**. Our stack requires Node 20+:
- Vite 7 → Node ≥ 20
- Vitest 4 → Node ≥ 20

This caused `exit code 127` (command not found) during the build step after `npm ci` succeeded.

## Fix

- `package.json` → added `"engines": { "node": ">=20" }`
- `render.yaml` → added `NODE_VERSION: "20"` env var (Render reads this to select the Node version for the build)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YYZrwW4pt8aYW7S16Gsmth)_