### PR TITLE
fix: replace shell-escaped esbuild with programmatic build-server.mjs (Render exit 127)

### DIFF
--- a/build-server.mjs
+++ b/build-server.mjs
@@ -1,0 +1,30 @@
+// build-server.mjs — programmatic esbuild (avoids shell quoting issues)
+import * as esbuild from "esbuild";
+
+await esbuild.build({
+  entryPoints: ["api/boot.ts"],
+  platform: "node",
+  bundle: true,
+  format: "esm",
+  outdir: "dist",
+  external: [
+    "@electric-sql/pglite",
+    "drizzle-orm",
+    "drizzle-orm/pglite",
+    "drizzle-orm/pg-core",
+    "drizzle-orm/node-postgres",
+    "pg",
+    "bcryptjs",
+    "uuid",
+    "superjson",
+    "hono",
+    "@hono/node-server",
+    "@trpc/server",
+    "@trpc/server/adapters/fetch",
+  ],
+  banner: {
+    js: "import { createRequire } from 'module'; const require = createRequire(import.meta.url);",
+  },
+});
+
+console.log("Server build complete → dist/boot.js");

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build && esbuild api/boot.ts --platform=node --bundle --format=esm --outdir=dist --external:@electric-sql/pglite --external:drizzle-orm --external:drizzle-orm/pglite --external:drizzle-orm/pg-core --external:drizzle-orm/node-postgres --external:pg --external:bcryptjs --external:uuid --external:superjson --external:hono --external:@hono/node-server --external:@trpc/server --external:@trpc/server/adapters/fetch --banner:js=\"import { createRequire } from 'module';const require = createRequire(import.meta.url);\"",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build && esbuild api/boot.ts --platform=node --bundle --format=esm --outdir=dist --external:@electric-sql/pglite --external:drizzle-orm --external:drizzle-orm/pglite --external:drizzle-orm/pg-core --external:drizzle-orm/node-postgres --external:pg --external:bcryptjs --external:uuid --external:superjson --external:hono --external:@hono/node-server --external:@trpc/server --external:@trpc/server/adapters/fetch --banner:js=\"import { createRequire } from 'module';const require = createRequire(import.meta.url);\"",
+    "build": "vite build && node build-server.mjs",
     "lint": "eslint .",
     "preview": "vite preview",
     "start": "NODE_ENV=production node dist/boot.js",

--- a/render.yaml
+++ b/render.yaml
@@ -12,6 +12,8 @@ services:
     startCommand: node dist/boot.js
     healthCheckPath: /api/health
     envVars:
+      - key: NODE_VERSION
+        value: "20"
       - key: NODE_ENV
         value: production
       - key: PORT


### PR DESCRIPTION
## Summary

- Replaces the complex shell-escaped `esbuild` one-liner in `npm run build` with a clean programmatic `build-server.mjs` script
- The `--banner:js="import { createRequire }..."` quoting was causing exit code 127 on Render's shell
- Build script is now just: `vite build && node build-server.mjs`

## Test plan

- [x] `npm run check` passes (TypeScript)
- [x] `npm run build` passes locally — `dist/boot.js` produced correctly
- [ ] Render build should now pass without exit 127

https://claude.ai/code/session_01YYZrwW4pt8aYW7S16Gsmth

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYZrwW4pt8aYW7S16Gsmth)_