### PR TITLE
fix: NODE_ENV=development for npm ci so vite/devDeps install on Render

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,7 @@ services:
     plan: free
     region: singapore
     branch: main
-    buildCommand: npm ci --include=dev && npm run build
+    buildCommand: NODE_ENV=development npm ci && npm run build
     startCommand: node dist/boot.js
     healthCheckPath: /api/health
     envVars:


### PR DESCRIPTION
## Root cause (verified locally)

```bash
NODE_ENV=production npm ci   → vite NOT installed → sh: 1: vite: not found (exit 127)
NODE_ENV=development npm ci && npm run build → builds OK ✓
```

`NODE_ENV=production` makes npm silently drop all devDependencies during `npm ci`. Vite, esbuild, and TypeScript are all in devDependencies, so none of them get installed.

## Fix

`buildCommand: NODE_ENV=development npm ci && npm run build`

Overrides NODE_ENV only for the install step so devDeps are always included. The build script itself still runs with whatever NODE_ENV Render exports (production), which is correct.

https://claude.ai/code/session_01YYZrwW4pt8aYW7S16Gsmth

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYZrwW4pt8aYW7S16Gsmth)_