### PR TITLE
Add env validation and docs for R2 and VAPID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,30 @@
 DATABASE_URL=./data/pglite
-SESSION_SECRET=change-me-to-a-random-secret-key
+SESSION_SECRET=replace-with-a-random-secret-at-least-32-characters
 NODE_ENV=development
-VITE_API_BASE=/api
-FRONTEND_ORIGIN=http://localhost:3000
 PORT=3000
+FRONTEND_ORIGIN=http://localhost:3000
+
+# Frontend API base. Use a full backend URL when frontend and API are on different domains.
+VITE_API_BASE=/api
+# Legacy alias kept for backward compatibility. Prefer VITE_API_BASE.
+VITE_API_URL=
+
+# Optional app credentials if you wire an external integration later.
+APP_ID=
+APP_SECRET=
+
+# Cloudflare R2 (leave blank unless uploads are moved off local disk)
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET_NAME=
+# Optional override. Default can be derived from R2_ACCOUNT_ID.
+R2_ENDPOINT=
+# Optional public CDN/base URL for uploaded objects.
+R2_PUBLIC_URL=
+
+# Web Push VAPID (leave blank unless browser push is enabled)
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+# Example: mailto:you@example.com
+VAPID_SUBJECT=

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -79,8 +79,18 @@ git push -u origin main
 | `NODE_ENV` | `production` |
 | `PORT` | `3000` |
 | `DATABASE_URL` | (Internal Database URL จากขั้นตอน 2.1) |
-| `SESSION_SECRET` | `qxwap-super-secret-key-change-me-32chars` |
+| `SESSION_SECRET` | (random string ยาวอย่างน้อย 32 ตัวอักษร) |
 | `FRONTEND_ORIGIN` | `https://aswer18400.github.io` |
+| `VITE_API_BASE` | `https://qxwap-backend.onrender.com/api` (ถ้า frontend build แยก) |
+| `R2_ACCOUNT_ID` | (optional, เมื่อเริ่มใช้ Cloudflare R2) |
+| `R2_ACCESS_KEY_ID` | (optional, เมื่อเริ่มใช้ Cloudflare R2) |
+| `R2_SECRET_ACCESS_KEY` | (optional secret, ห้าม commit) |
+| `R2_BUCKET_NAME` | (optional, เมื่อเริ่มใช้ Cloudflare R2) |
+| `R2_ENDPOINT` | `https://<account-id>.r2.cloudflarestorage.com` (optional override) |
+| `R2_PUBLIC_URL` | `https://pub-...r2.dev` (optional public asset URL) |
+| `VAPID_SUBJECT` | `mailto:you@example.com` (optional, เมื่อเริ่มใช้ Web Push) |
+| `VAPID_PUBLIC_KEY` | (optional, generated) |
+| `VAPID_PRIVATE_KEY` | (optional secret, ห้าม commit) |
 
 6. คลิก **Create Web Service**
 7. รอ ~5-10 นาทีให้ build และ deploy เสร็จ

--- a/README.md
+++ b/README.md
@@ -65,8 +65,18 @@ NODE_ENV=production node dist/boot.js
 | `SESSION_SECRET` | Secret for cookie session signing | `long-random-string` |
 | `NODE_ENV` | Environment mode | `development` or `production` |
 | `VITE_API_BASE` | API base path for frontend | `/api` |
+| `VITE_API_URL` | Legacy frontend API base alias; fallback if `VITE_API_BASE` is unset | `https://your-backend.onrender.com/api` |
 | `FRONTEND_ORIGIN` | Allowed CORS origin in production | `https://qxwap.github.io` |
 | `PORT` | Production server port | `3000` |
+| `R2_ACCOUNT_ID` | Cloudflare account ID for R2 upload integration | `0123456789abcdef` |
+| `R2_ACCESS_KEY_ID` | R2 access key ID | `your-r2-access-key-id` |
+| `R2_SECRET_ACCESS_KEY` | R2 secret access key | `your-r2-secret-access-key` |
+| `R2_BUCKET_NAME` | R2 bucket name | `qxwap-uploads` |
+| `R2_ENDPOINT` | Optional custom R2 endpoint override | `https://<account>.r2.cloudflarestorage.com` |
+| `R2_PUBLIC_URL` | Optional public base URL/CDN URL for uploaded assets | `https://pub-xxx.r2.dev` |
+| `VAPID_SUBJECT` | Web Push contact URI | `mailto:you@example.com` |
+| `VAPID_PUBLIC_KEY` | Web Push VAPID public key | `BExamplePublicKey` |
+| `VAPID_PRIVATE_KEY` | Web Push VAPID private key | `ExamplePrivateKey` |
 
 ## API Overview
 
@@ -114,7 +124,9 @@ NODE_ENV=production node dist/boot.js
 2. Set `DATABASE_URL` to a real PostgreSQL connection string (e.g., Supabase).
 3. Set `SESSION_SECRET` to a strong random string.
 4. Set `FRONTEND_ORIGIN` to your deployed frontend URL.
-5. Start with `NODE_ENV=production node dist/boot.js`
+5. If you enable Cloudflare R2 uploads later, set `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, and `R2_BUCKET_NAME` together.
+6. If you enable Web Push later, set `VAPID_SUBJECT`, `VAPID_PUBLIC_KEY`, and `VAPID_PRIVATE_KEY` together.
+7. Start with `NODE_ENV=production node dist/boot.js`
 
 ### Database Migration (Production)
 

--- a/RENDER_DEPLOY.md
+++ b/RENDER_DEPLOY.md
@@ -47,6 +47,16 @@
 | `DATABASE_URL` | (Internal Database URL จาก Step 1) |
 | `SESSION_SECRET` | (สร้าง random string ยาว 32+ ตัว) |
 | `FRONTEND_ORIGIN` | (URL ของ frontend ที่ deploy ไว้) |
+| `VITE_API_BASE` | `https://your-backend.onrender.com/api` (ถ้า build frontend บน Render/CI) |
+| `R2_ACCOUNT_ID` | (optional, ถ้าใช้ Cloudflare R2) |
+| `R2_ACCESS_KEY_ID` | (optional, ถ้าใช้ Cloudflare R2) |
+| `R2_SECRET_ACCESS_KEY` | (optional secret, ห้าม commit) |
+| `R2_BUCKET_NAME` | (optional, ถ้าใช้ Cloudflare R2) |
+| `R2_ENDPOINT` | `https://<accountid>.r2.cloudflarestorage.com` (optional override) |
+| `R2_PUBLIC_URL` | `https://pub-...r2.dev` หรือ custom domain (optional) |
+| `VAPID_SUBJECT` | `mailto:you@example.com` หรือ `https://your-domain.com` (optional, ถ้าเปิด Web Push) |
+| `VAPID_PUBLIC_KEY` | (optional, ถ้าเปิด Web Push) |
+| `VAPID_PRIVATE_KEY` | (optional secret, ห้าม commit) |
 
 6. คลิก **Create Web Service**
 
@@ -113,6 +123,16 @@ docker-compose down
 | `NODE_ENV` | ✅ | `production` |
 | `PORT` | ✅ | `3000` |
 | `FRONTEND_ORIGIN` | ✅ | Frontend URL สำหรับ CORS |
+| `VITE_API_BASE` | Recommended | URL ของ backend `/api` สำหรับ frontend build แยกโดเมน |
+| `R2_ACCOUNT_ID` | Optional | Cloudflare account ID สำหรับ R2 |
+| `R2_ACCESS_KEY_ID` | Optional | R2 access key ID |
+| `R2_SECRET_ACCESS_KEY` | Optional secret | R2 secret access key |
+| `R2_BUCKET_NAME` | Optional | ชื่อ bucket บน R2 |
+| `R2_ENDPOINT` | Optional | custom endpoint; ถ้าไม่ใส่จะ derive จาก account ID |
+| `R2_PUBLIC_URL` | Optional | public base URL สำหรับไฟล์บน R2 |
+| `VAPID_SUBJECT` | Optional | `mailto:` หรือ `https://` subject สำหรับ Web Push |
+| `VAPID_PUBLIC_KEY` | Optional | public key สำหรับ Web Push |
+| `VAPID_PRIVATE_KEY` | Optional secret | private key สำหรับ Web Push |
 
 ## ตรวจสอบหลัง Deploy
 
@@ -133,6 +153,7 @@ docker-compose down
 
 ### ปัญหา: Frontend เรียก API ไม่เจอ
 - ตรวจสอบว่า `window.API_BASE` ถูก inject ด้วย URL จริง
+- หรือกำหนด `VITE_API_BASE=https://your-backend.onrender.com/api` ตอน build frontend
 - ดู Network tab ใน DevTools ตรวจสอบ request URL
 
 ### ปัญหา: Session ไม่คงอยู่

--- a/api/boot.ts
+++ b/api/boot.ts
@@ -15,7 +15,7 @@ const app = new Hono<{ Bindings: HttpBindings }>();
 const DB_HEALTH_TIMEOUT_MS = 3000;
 
 app.use(cors({
-  origin: env.isProduction ? (process.env.FRONTEND_ORIGIN || "") : "http://localhost:3000",
+  origin: env.frontendOrigin,
   credentials: true,
 }));
 

--- a/api/lib/env.test.ts
+++ b/api/lib/env.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { parseServerEnv } from "./env";
+
+describe("parseServerEnv", () => {
+  it("accepts local development defaults", () => {
+    const env = parseServerEnv({
+      NODE_ENV: "development",
+      DATABASE_URL: "./data/pglite",
+    });
+
+    expect(env.databaseUrl).toBe("./data/pglite");
+    expect(env.frontendOrigin).toBe("http://localhost:3000");
+    expect(env.port).toBe(3000);
+    expect(env.sessionSecret).toBe("default-secret-change-me");
+    expect(env.r2).toBeNull();
+    expect(env.vapid).toBeNull();
+  });
+
+  it("fails fast when production env is missing required values", () => {
+    expect(() => parseServerEnv({
+      NODE_ENV: "production",
+      DATABASE_URL: "postgresql://localhost:5432/qxwap",
+    })).toThrowError(/FRONTEND_ORIGIN is required/);
+  });
+
+  it("rejects incomplete R2 config", () => {
+    expect(() => parseServerEnv({
+      NODE_ENV: "development",
+      DATABASE_URL: "./data/pglite",
+      R2_ACCOUNT_ID: "account",
+      R2_BUCKET_NAME: "bucket",
+    })).toThrowError(/Cloudflare R2 config is incomplete/);
+  });
+
+  it("rejects incomplete VAPID config", () => {
+    expect(() => parseServerEnv({
+      NODE_ENV: "development",
+      DATABASE_URL: "./data/pglite",
+      VAPID_PUBLIC_KEY: "public-key",
+    })).toThrowError(/Web Push VAPID config is incomplete/);
+  });
+});

--- a/api/lib/env.ts
+++ b/api/lib/env.ts
@@ -1,10 +1,147 @@
 import "dotenv/config";
+import { z } from "zod";
 
-export const env = {
-  appId: process.env.APP_ID ?? "",
-  appSecret: process.env.APP_SECRET ?? "",
-  isProduction: process.env.NODE_ENV === "production",
-  databaseUrl: process.env.DATABASE_URL || "./data/pglite",
-  sessionSecret: process.env.SESSION_SECRET || "default-secret-change-me",
-  port: parseInt(process.env.PORT || "3000"),
+const blankToUndefined = (value: unknown) => {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed;
 };
+
+const optionalString = () => z.preprocess(blankToUndefined, z.string().optional());
+const optionalUrl = (name: string) => z.preprocess(
+  blankToUndefined,
+  z.string().url({ message: `${name} must be a valid URL` }).optional(),
+);
+
+const rawEnvSchema = z.object({
+  APP_ID: optionalString(),
+  APP_SECRET: optionalString(),
+  DATABASE_URL: z.preprocess(blankToUndefined, z.string().default("./data/pglite")),
+  FRONTEND_ORIGIN: optionalUrl("FRONTEND_ORIGIN"),
+  NODE_ENV: z.preprocess(blankToUndefined, z.enum(["development", "test", "production"]).default("development")),
+  PORT: z.preprocess(blankToUndefined, z.coerce.number().int().positive().default(3000)),
+  SESSION_SECRET: optionalString(),
+  R2_ACCOUNT_ID: optionalString(),
+  R2_ACCESS_KEY_ID: optionalString(),
+  R2_SECRET_ACCESS_KEY: optionalString(),
+  R2_BUCKET_NAME: optionalString(),
+  R2_ENDPOINT: optionalUrl("R2_ENDPOINT"),
+  R2_PUBLIC_URL: optionalUrl("R2_PUBLIC_URL"),
+  VAPID_PRIVATE_KEY: optionalString(),
+  VAPID_PUBLIC_KEY: optionalString(),
+  VAPID_SUBJECT: optionalString(),
+});
+
+type RawEnv = z.infer<typeof rawEnvSchema>;
+
+function formatZodPath(path: PropertyKey[]) {
+  return path.length ? path.join(".") : "environment";
+}
+
+function createEnvError(messages: string[]) {
+  return new Error(`Invalid environment configuration:\n- ${messages.join("\n- ")}`);
+}
+
+function validateGroupedEnv(parsed: RawEnv) {
+  const issues: string[] = [];
+
+  if (parsed.NODE_ENV === "production") {
+    if (!parsed.FRONTEND_ORIGIN) {
+      issues.push("FRONTEND_ORIGIN is required when NODE_ENV=production.");
+    }
+    if (!parsed.SESSION_SECRET) {
+      issues.push("SESSION_SECRET is required when NODE_ENV=production.");
+    } else if (parsed.SESSION_SECRET.length < 32) {
+      issues.push("SESSION_SECRET must be at least 32 characters when NODE_ENV=production.");
+    }
+  }
+
+  const requiredR2Keys = [
+    "R2_ACCOUNT_ID",
+    "R2_ACCESS_KEY_ID",
+    "R2_SECRET_ACCESS_KEY",
+    "R2_BUCKET_NAME",
+  ] as const;
+  const hasAnyR2 = requiredR2Keys.some((key) => parsed[key]) || !!parsed.R2_ENDPOINT || !!parsed.R2_PUBLIC_URL;
+  if (hasAnyR2) {
+    const missing = requiredR2Keys.filter((key) => !parsed[key]);
+    if (missing.length) {
+      issues.push(`Cloudflare R2 config is incomplete. Missing: ${missing.join(", ")}.`);
+    }
+  }
+
+  const requiredVapidKeys = [
+    "VAPID_SUBJECT",
+    "VAPID_PUBLIC_KEY",
+    "VAPID_PRIVATE_KEY",
+  ] as const;
+  const hasAnyVapid = requiredVapidKeys.some((key) => parsed[key]);
+  if (hasAnyVapid) {
+    const missing = requiredVapidKeys.filter((key) => !parsed[key]);
+    if (missing.length) {
+      issues.push(`Web Push VAPID config is incomplete. Missing: ${missing.join(", ")}.`);
+    }
+
+    if (parsed.VAPID_SUBJECT && !/^(mailto:|https:\/\/)/.test(parsed.VAPID_SUBJECT)) {
+      issues.push("VAPID_SUBJECT must start with mailto: or https://.");
+    }
+  }
+
+  if (issues.length) {
+    throw createEnvError(issues);
+  }
+}
+
+export function parseServerEnv(source: NodeJS.ProcessEnv = process.env) {
+  const result = rawEnvSchema.safeParse(source);
+
+  if (!result.success) {
+    throw createEnvError(result.error.issues.map((issue) => `${formatZodPath(issue.path)}: ${issue.message}`));
+  }
+
+  const parsed = result.data;
+  validateGroupedEnv(parsed);
+
+  const defaultSessionSecret = parsed.NODE_ENV === "production" ? "" : "default-secret-change-me";
+  const hasCompleteR2Config = !!(
+    parsed.R2_ACCOUNT_ID
+    && parsed.R2_ACCESS_KEY_ID
+    && parsed.R2_SECRET_ACCESS_KEY
+    && parsed.R2_BUCKET_NAME
+  );
+  const hasCompleteVapidConfig = !!(
+    parsed.VAPID_SUBJECT
+    && parsed.VAPID_PUBLIC_KEY
+    && parsed.VAPID_PRIVATE_KEY
+  );
+
+  return {
+    appId: parsed.APP_ID ?? "",
+    appSecret: parsed.APP_SECRET ?? "",
+    databaseUrl: parsed.DATABASE_URL,
+    frontendOrigin: parsed.FRONTEND_ORIGIN ?? "http://localhost:3000",
+    isProduction: parsed.NODE_ENV === "production",
+    nodeEnv: parsed.NODE_ENV,
+    port: parsed.PORT,
+    r2: hasCompleteR2Config
+      ? {
+          accountId: parsed.R2_ACCOUNT_ID!,
+          accessKeyId: parsed.R2_ACCESS_KEY_ID!,
+          bucketName: parsed.R2_BUCKET_NAME!,
+          endpoint: parsed.R2_ENDPOINT ?? `https://${parsed.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+          publicUrl: parsed.R2_PUBLIC_URL ?? "",
+          secretAccessKey: parsed.R2_SECRET_ACCESS_KEY!,
+        }
+      : null,
+    sessionSecret: parsed.SESSION_SECRET ?? defaultSessionSecret,
+    vapid: hasCompleteVapidConfig
+      ? {
+          privateKey: parsed.VAPID_PRIVATE_KEY!,
+          publicKey: parsed.VAPID_PUBLIC_KEY!,
+          subject: parsed.VAPID_SUBJECT!,
+        }
+      : null,
+  };
+}
+
+export const env = parseServerEnv();

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -2,12 +2,15 @@ import "dotenv/config";
 import path from "node:path";
 import { defineConfig } from "drizzle-kit";
 
+const databaseUrl = process.env.DATABASE_URL || "./data/pglite";
+const isRemotePostgres = /^postgres(ql)?:\/\//i.test(databaseUrl);
+
 export default defineConfig({
   schema: "./db/schema.ts",
   out: "./db/migrations",
   dialect: "postgresql",
-  driver: "pglite",
+  driver: isRemotePostgres ? undefined : "pglite",
   dbCredentials: {
-    url: path.resolve(process.cwd(), process.env.DATABASE_URL || "./data/pglite"),
+    url: isRemotePostgres ? databaseUrl : path.resolve(process.cwd(), databaseUrl),
   },
 });

--- a/src/lib/apiBase.test.ts
+++ b/src/lib/apiBase.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { getApiBase, getApiUrl } from "./apiBase";
+
+describe("apiBase helpers", () => {
+  it("prefers VITE_API_BASE over VITE_API_URL", () => {
+    vi.stubEnv("VITE_API_BASE", "https://api.example.com/api/");
+    vi.stubEnv("VITE_API_URL", "https://legacy.example.com/api");
+
+    expect(getApiBase()).toBe("https://api.example.com/api");
+    expect(getApiUrl("/auth/me")).toBe("https://api.example.com/api/auth/me");
+
+    vi.unstubAllEnvs();
+  });
+
+  it("falls back to VITE_API_URL when VITE_API_BASE is unset", () => {
+    vi.stubEnv("VITE_API_BASE", "");
+    vi.stubEnv("VITE_API_URL", "https://legacy.example.com/api/");
+
+    expect(getApiBase()).toBe("https://legacy.example.com/api");
+    expect(getApiUrl("upload")).toBe("https://legacy.example.com/api/upload");
+
+    vi.unstubAllEnvs();
+  });
+
+  it("uses same-origin /api when no frontend env is provided", () => {
+    vi.stubEnv("VITE_API_BASE", "");
+    vi.stubEnv("VITE_API_URL", "");
+
+    expect(getApiBase()).toBe("/api");
+    expect(getApiUrl("/auth/signin")).toBe("/api/auth/signin");
+
+    vi.unstubAllEnvs();
+  });
+});

--- a/src/lib/apiBase.ts
+++ b/src/lib/apiBase.ts
@@ -1,0 +1,20 @@
+function readWindowApiBase() {
+  if (typeof window === "undefined") return undefined;
+  const apiBase = (window as Window & { API_BASE?: unknown }).API_BASE;
+  return typeof apiBase === "string" && apiBase.trim() ? apiBase : undefined;
+}
+
+export function getApiBase() {
+  const configuredBase = readWindowApiBase()
+    || import.meta.env.VITE_API_BASE
+    || import.meta.env.VITE_API_URL
+    || "/api";
+
+  return configuredBase.replace(/\/+$/, "");
+}
+
+export function getApiUrl(path: string) {
+  if (/^https?:\/\//i.test(path)) return path;
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${getApiBase()}${normalizedPath}`;
+}

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,4 +1,4 @@
-const API_BASE_URL = (import.meta.env.VITE_API_URL || "").replace(/\/$/, "");
+import { getApiUrl } from "@/lib/apiBase";
 
 export class ApiClientError extends Error {
   status?: number;
@@ -25,12 +25,6 @@ export class ApiClientError extends Error {
     this.responsePreview = options.responsePreview;
     this.payload = options.payload;
   }
-}
-
-function getApiUrl(path: string) {
-  if (/^https?:\/\//i.test(path)) return path;
-  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-  return `${API_BASE_URL}${normalizedPath}`;
 }
 
 function getErrorMessage(payload: unknown, fallback: string) {

--- a/src/pages/AddProduct.tsx
+++ b/src/pages/AddProduct.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import { Camera, X, ArrowLeft } from 'lucide-react'
+import { getApiUrl } from '@/lib/apiBase'
 
 const DEAL_TYPES = [
   { key: 'swap', label: 'แลก', sub: 'แลกเปลี่ยน', icon: '🔁', color: 'border-purple-200 bg-purple-50 text-purple-700' },
@@ -57,7 +58,7 @@ export default function AddProduct() {
     const form = new FormData()
     for (let i = 0; i < files.length; i++) form.append('images', files[i])
     try {
-      const res = await fetch('/api/upload', { method: 'POST', body: form })
+      const res = await fetch(getApiUrl('/api/upload'), { method: 'POST', body: form, credentials: 'include' })
       const data = await res.json()
       if (data.urls) setImages((prev) => [...prev, ...data.urls])
     } catch {

--- a/src/pages/EditProfile.tsx
+++ b/src/pages/EditProfile.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import { Camera, ArrowLeft } from 'lucide-react'
+import { getApiUrl } from '@/lib/apiBase'
 
 export default function EditProfile() {
   const navigate = useNavigate()
@@ -38,7 +39,7 @@ export default function EditProfile() {
     const form = new FormData()
     form.append('images', file)
     try {
-      const res = await fetch('/api/upload', { method: 'POST', body: form })
+      const res = await fetch(getApiUrl('/api/upload'), { method: 'POST', body: form, credentials: 'include' })
       const data = await res.json()
       if (data.urls?.[0]) setAvatarUrl(data.urls[0])
     } catch {

--- a/src/providers/trpc.tsx
+++ b/src/providers/trpc.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import superjson from "superjson";
 import type { AppRouter } from "../../api/router";
 import type { ReactNode } from "react";
+import { getApiBase } from "@/lib/apiBase";
 
 export const trpc = createTRPCReact<AppRouter>();
 
@@ -15,11 +16,6 @@ const queryClient = new QueryClient({
     },
   },
 });
-
-function getApiBase() {
-  const base = (typeof window !== "undefined" && (window as any).API_BASE) || import.meta.env.VITE_API_BASE || "/api";
-  return base.replace(/\/+$/, "");
-}
 
 const trpcClient = trpc.createClient({
   links: [

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,8 @@
+interface ImportMetaEnv {
+  readonly VITE_API_BASE?: string;
+  readonly VITE_API_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- centralize server env parsing/validation for production, Cloudflare R2, and Web Push VAPID settings
- align frontend API base handling so auth, upload, and tRPC use the same env-driven base URL
- update `.env.example` and deployment docs with the required Render env names and secret-handling notes

## Testing
- `npm run check`
- `npm test`
- `npm run build`
- `npx web-push generate-vapid-keys` (generated keys locally; private key not committed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71723d80-cc60-454b-a30b-852bfd4440a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71723d80-cc60-454b-a30b-852bfd4440a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

