### PR TITLE
fix: mobile QA bugs + UX improvements across all major pages

### DIFF
--- a/src/components/FilterSheet.tsx
+++ b/src/components/FilterSheet.tsx
@@ -75,11 +75,11 @@ export default function FilterSheet({ open, onClose, onApply, initialFilters }: 
 
   return (
     <Sheet open={open} onOpenChange={onClose}>
-      <SheetContent side="bottom" className="h-[85vh] rounded-t-2xl">
-        <SheetHeader>
+      <SheetContent side="bottom" className="rounded-t-2xl flex flex-col" style={{ maxHeight: '88vh' }}>
+        <SheetHeader className="flex-shrink-0">
           <SheetTitle>ตัวกรอง {activeCount > 0 && <span className="ml-2 text-xs bg-blue-600 text-white px-2 py-0.5 rounded-full">{activeCount}</span>}</SheetTitle>
         </SheetHeader>
-        <div className="mt-4 space-y-5 overflow-y-auto pb-20">
+        <div className="flex-1 overflow-y-auto mt-4 space-y-5 pb-4">
           <div>
             <Label>หมวดหมู่</Label>
             <div className="flex flex-wrap gap-2 mt-2">

--- a/src/components/OfferSheet.tsx
+++ b/src/components/OfferSheet.tsx
@@ -11,19 +11,38 @@ export default function OfferSheet({ open, onClose, item }: { open: boolean; onC
   const [message, setMessage] = useState('')
   const [cash, setCash] = useState('')
   const [credit, setCredit] = useState('')
+  const [error, setError] = useState('')
   const utils = trpc.useContext()
 
-  const myItems = trpc.item.list.useQuery({ ownerId: user?.id, limit: 50 }, { enabled: !!user })
+  const myItems = trpc.item.list.useQuery(
+    { ownerId: user?.id, limit: 50 },
+    { enabled: !!user && open }
+  )
   const [selectedItems, setSelectedItems] = useState<string[]>([])
 
   const createOffer = trpc.offer.create.useMutation({
     onSuccess: () => {
       utils.offer.list.invalidate()
+      setMessage('')
+      setCash('')
+      setCredit('')
+      setSelectedItems([])
+      setError('')
       onClose()
+    },
+    onError: (err) => {
+      setError(err.message || 'ส่งข้อเสนอไม่สำเร็จ')
     },
   })
 
+  const hasContent = message.trim() || (cash && Number(cash) > 0) || (credit && Number(credit) > 0) || selectedItems.length > 0
+
   const submit = () => {
+    if (!hasContent) {
+      setError('กรุณาระบุข้อเสนอ: ข้อความ เงินสด เครดิต หรือเลือกสินค้า')
+      return
+    }
+    setError('')
     createOffer.mutate({
       targetItemId: item.id,
       toUserId: item.ownerId,
@@ -35,38 +54,58 @@ export default function OfferSheet({ open, onClose, item }: { open: boolean; onC
   }
 
   return (
-    <Sheet open={open} onOpenChange={onClose}>
-      <SheetContent side="bottom" className="h-[85vh] rounded-t-2xl">
-        <SheetHeader>
+    <Sheet open={open} onOpenChange={(v) => { if (!v) onClose() }}>
+      <SheetContent side="bottom" className="rounded-t-2xl flex flex-col" style={{ maxHeight: '85vh' }}>
+        <SheetHeader className="flex-shrink-0">
           <SheetTitle>ส่งข้อเสนอ</SheetTitle>
         </SheetHeader>
-        <div className="mt-4 space-y-4 overflow-y-auto pb-10">
+        <div className="flex-1 overflow-y-auto mt-4 space-y-4 pb-4">
           <div className="bg-gray-50 rounded-xl p-3 text-sm">
-            <p className="font-medium">{item.title}</p>
-            <p className="text-gray-500 text-xs">ของ {item.owner?.profile?.displayName || item.owner?.email}</p>
+            <p className="font-medium truncate">{item.title}</p>
+            <p className="text-gray-500 text-xs">ของ {item.owner?.profile?.displayName || item.owner?.email || 'ผู้ใช้'}</p>
           </div>
 
           <div>
-            <label className="text-sm text-gray-600">ข้อความ</label>
-            <Textarea value={message} onChange={(e) => setMessage(e.target.value)} placeholder="เขียนข้อเสนอ..." className="rounded-xl" />
+            <label className="text-sm font-medium text-gray-700 mb-1.5 block">ข้อความ</label>
+            <Textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder="เขียนข้อเสนอของคุณ..."
+              className="rounded-xl"
+              rows={3}
+            />
           </div>
 
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="text-sm text-gray-600">เงินสด (บาท)</label>
-              <Input type="number" value={cash} onChange={(e) => setCash(e.target.value)} className="rounded-xl" />
+              <label className="text-sm font-medium text-gray-700 mb-1.5 block">เงินสด (บาท)</label>
+              <Input
+                type="number"
+                value={cash}
+                onChange={(e) => setCash(e.target.value)}
+                placeholder="0"
+                className="rounded-xl"
+              />
             </div>
             <div>
-              <label className="text-sm text-gray-600">เครดิต</label>
-              <Input type="number" value={credit} onChange={(e) => setCredit(e.target.value)} className="rounded-xl" />
+              <label className="text-sm font-medium text-gray-700 mb-1.5 block">เครดิต</label>
+              <Input
+                type="number"
+                value={credit}
+                onChange={(e) => setCredit(e.target.value)}
+                placeholder="0"
+                className="rounded-xl"
+              />
             </div>
           </div>
 
           <div>
-            <label className="text-sm text-gray-600">เลือกสินค้าของคุณ (ถ้ามี)</label>
-            <div className="mt-2 space-y-2 max-h-40 overflow-y-auto">
+            <label className="text-sm font-medium text-gray-700 mb-1.5 block">
+              เลือกสินค้าของคุณ {myItems.data?.length ? `(${myItems.data.length} รายการ)` : ''}
+            </label>
+            <div className="space-y-2 max-h-44 overflow-y-auto">
               {(myItems.data || []).map((it: any) => (
-                <label key={it.id} className="flex items-center gap-3 bg-gray-50 rounded-xl p-2">
+                <label key={it.id} className="flex items-center gap-3 bg-gray-50 rounded-xl p-2 cursor-pointer">
                   <input
                     type="checkbox"
                     checked={selectedItems.includes(it.id)}
@@ -74,18 +113,29 @@ export default function OfferSheet({ open, onClose, item }: { open: boolean; onC
                       if (e.target.checked) setSelectedItems([...selectedItems, it.id])
                       else setSelectedItems(selectedItems.filter((id) => id !== it.id))
                     }}
+                    className="w-4 h-4 accent-blue-600"
                   />
-                  <div className="w-10 h-10 bg-gray-200 rounded-lg overflow-hidden">
-                    {it.images?.[0]?.url && <img src={it.images[0].url} alt="" className="w-full h-full object-cover" />}
+                  <div className="w-10 h-10 bg-gray-200 rounded-lg overflow-hidden flex-shrink-0">
+                    {it.images?.[0]?.url && <img src={it.images[0].url} alt="" className="w-full h-full object-cover" loading="lazy" />}
                   </div>
                   <span className="text-sm truncate">{it.title}</span>
                 </label>
               ))}
-              {!myItems.data?.length && <p className="text-xs text-gray-400">คุณยังไม่มีสินค้า สามารถส่งข้อเสนอด้วยข้อความ/เงิน/เครดิตได้</p>}
+              {!myItems.isPending && !myItems.data?.length && (
+                <p className="text-xs text-gray-400 py-2">คุณยังไม่มีสินค้า — ส่งข้อเสนอด้วยข้อความ เงิน หรือเครดิตได้เลย</p>
+              )}
             </div>
           </div>
 
-          <Button className="w-full rounded-xl bg-blue-600 hover:bg-blue-700" onClick={submit} disabled={createOffer.isPending}>
+          {error && (
+            <p className="text-sm text-red-600 bg-red-50 rounded-xl px-3 py-2">{error}</p>
+          )}
+
+          <Button
+            className="w-full rounded-xl bg-blue-600 hover:bg-blue-700 h-12 font-semibold"
+            onClick={submit}
+            disabled={createOffer.isPending}
+          >
             {createOffer.isPending ? 'กำลังส่ง...' : 'ส่งข้อเสนอ'}
           </Button>
         </div>

--- a/src/pages/AddProduct.tsx
+++ b/src/pages/AddProduct.tsx
@@ -1,27 +1,30 @@
-import { useState, useRef } from 'react'
-import { useNavigate } from 'react-router'
+import { useState, useRef, useEffect } from 'react'
+import { useNavigate, useSearchParams } from 'react-router'
 import { trpc } from '@/providers/trpc'
 import { useAuth } from '@/hooks/useAuth'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
-import { Camera, X, ArrowLeft } from 'lucide-react'
+import { Camera, X, ArrowLeft, Plus } from 'lucide-react'
 
 const DEAL_TYPES = [
-  { key: 'swap', label: 'แลก', sub: 'แลกเปลี่ยน', icon: '🔁', color: 'border-purple-200 bg-purple-50 text-purple-700' },
-  { key: 'sell', label: 'ขาย', sub: 'ขายสินค้า', icon: '💰', color: 'border-green-200 bg-green-50 text-green-700' },
-  { key: 'buy', label: 'ต้องการซื้อ', sub: 'ประกาศหาซื้อ', icon: '🛒', color: 'border-blue-200 bg-blue-50 text-blue-700' },
-  { key: 'both', label: 'ขายหรือแลก', sub: 'ได้ทั้งสองแบบ', icon: '💱', color: 'border-amber-200 bg-amber-50 text-amber-700' },
+  { key: 'swap', label: 'แลก', sub: 'แลกเปลี่ยน', icon: '🔁', color: 'border-purple-200 bg-purple-50 text-purple-700', ring: 'ring-purple-400' },
+  { key: 'sell', label: 'ขาย', sub: 'ขายสินค้า', icon: '💰', color: 'border-green-200 bg-green-50 text-green-700', ring: 'ring-green-400' },
+  { key: 'buy', label: 'ต้องการซื้อ', sub: 'ประกาศหาซื้อ', icon: '🛒', color: 'border-blue-200 bg-blue-50 text-blue-700', ring: 'ring-blue-400' },
+  { key: 'both', label: 'ขายหรือแลก', sub: 'ได้ทั้งสองแบบ', icon: '💱', color: 'border-amber-200 bg-amber-50 text-amber-700', ring: 'ring-amber-400' },
 ]
 
-const CATEGORIES = ['Electronics','Fashion','Home','Sports','Vehicles','Collectibles','Books','Beauty','Toys','Other']
-const CONDITIONS = ['New','Like new','Good','Used']
+const CATEGORIES = ['Electronics', 'Fashion', 'Home', 'Sports', 'Vehicles', 'Collectibles', 'Books', 'Beauty', 'Toys', 'Other']
+const CONDITIONS = ['New', 'Like new', 'Good', 'Used']
 
 export default function AddProduct() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const editId = searchParams.get('edit')
   const { user } = useAuth()
   const fileRef = useRef<HTMLInputElement>(null)
+  const tagInputRef = useRef<HTMLInputElement>(null)
 
   const [dealType, setDealType] = useState('swap')
   const [title, setTitle] = useState('')
@@ -32,13 +35,53 @@ export default function AddProduct() {
   const [priceCash, setPriceCash] = useState('')
   const [priceCredit, setPriceCredit] = useState('')
   const [openToOffers, setOpenToOffers] = useState(false)
-  const [wantedTags, setWantedTags] = useState<string[]>([''])
+  const [wantedTags, setWantedTags] = useState<string[]>([])
   const [wantedText, setWantedText] = useState('')
   const [images, setImages] = useState<string[]>([])
   const [uploading, setUploading] = useState(false)
+  const [tagInput, setTagInput] = useState('')
+  const [loaded, setLoaded] = useState(!editId)
+
+  const utils = trpc.useContext()
+
+  const existingItem = trpc.item.byId.useQuery(
+    { id: editId! },
+    { enabled: !!editId }
+  )
+
+  useEffect(() => {
+    if (editId && existingItem.data && !loaded) {
+      const it = existingItem.data
+      setDealType(it.dealType || 'swap')
+      setTitle(it.title || '')
+      setDescription(it.description || '')
+      setCategory(it.category || '')
+      setCondition(it.condition || '')
+      setLocationLabel(it.locationLabel || '')
+      setPriceCash(it.priceCash ? String(it.priceCash) : '')
+      setPriceCredit(it.priceCredit ? String(it.priceCredit) : '')
+      setOpenToOffers(!!it.openToOffers)
+      setWantedTags(it.wantedTags || [])
+      setWantedText(it.wantedText || '')
+      setImages((it.images || []).map((img: any) => img.url))
+      setLoaded(true)
+    }
+  }, [editId, existingItem.data, loaded])
 
   const createItem = trpc.item.create.useMutation({
-    onSuccess: () => { navigate('/') },
+    onSuccess: (data) => {
+      utils.item.list.invalidate()
+      utils.item.feed.invalidate()
+      navigate(`/item/${data.id}`)
+    },
+  })
+
+  const updateItem = trpc.item.update.useMutation({
+    onSuccess: () => {
+      utils.item.list.invalidate()
+      utils.item.byId.invalidate({ id: editId! })
+      navigate(`/item/${editId}`)
+    },
   })
 
   if (!user) {
@@ -50,6 +93,19 @@ export default function AddProduct() {
     )
   }
 
+  if (editId && existingItem.isLoading) {
+    return (
+      <div className="max-w-md mx-auto min-h-screen flex items-center justify-center text-gray-400">
+        กำลังโหลด...
+      </div>
+    )
+  }
+
+  if (editId && existingItem.data && existingItem.data.ownerId !== user.id) {
+    navigate('/')
+    return null
+  }
+
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files
     if (!files || !files.length) return
@@ -57,7 +113,7 @@ export default function AddProduct() {
     const form = new FormData()
     for (let i = 0; i < files.length; i++) form.append('images', files[i])
     try {
-      const res = await fetch('/api/upload', { method: 'POST', body: form })
+      const res = await fetch('/api/upload', { method: 'POST', body: form, credentials: 'include' })
       const data = await res.json()
       if (data.urls) setImages((prev) => [...prev, ...data.urls])
     } catch {
@@ -68,10 +124,18 @@ export default function AddProduct() {
     }
   }
 
+  const addTag = () => {
+    const val = tagInput.trim()
+    if (val && !wantedTags.includes(val)) {
+      setWantedTags([...wantedTags, val])
+    }
+    setTagInput('')
+  }
+
   const submit = (e: React.FormEvent) => {
     e.preventDefault()
     if (!title.trim()) return
-    createItem.mutate({
+    const payload = {
       title,
       description,
       category,
@@ -81,11 +145,18 @@ export default function AddProduct() {
       priceCredit: priceCredit ? Number(priceCredit) : undefined,
       openToOffers,
       wantedText,
-      wantedTags: wantedTags.filter(Boolean),
+      wantedTags,
       locationLabel,
       images,
-    })
+    }
+    if (editId) {
+      updateItem.mutate({ id: editId, ...payload })
+    } else {
+      createItem.mutate(payload)
+    }
   }
+
+  const isPending = createItem.isPending || updateItem.isPending
 
   return (
     <div className="max-w-md mx-auto min-h-screen bg-gray-50">
@@ -94,20 +165,24 @@ export default function AddProduct() {
         <button onClick={() => navigate(-1)} className="w-10 h-10 flex items-center justify-center rounded-full bg-gray-100 active:bg-gray-200 transition">
           <ArrowLeft size={20} />
         </button>
-        <h1 className="text-lg font-bold">โพสต์สินค้า</h1>
+        <h1 className="text-lg font-bold">{editId ? 'แก้ไขสินค้า' : 'โพสต์สินค้า'}</h1>
       </div>
 
       <form onSubmit={submit} className="p-4 space-y-5 pb-28">
-        {/* Deal type */}
+        {/* Deal type — icon cards */}
         <div>
-          <Label className="text-sm font-semibold text-gray-900 mb-3 block">เลือกประเภท</Label>
+          <Label className="text-sm font-semibold text-gray-900 mb-3 block">ประเภทดีล</Label>
           <div className="grid grid-cols-2 gap-3">
             {DEAL_TYPES.map((d) => (
               <button
                 key={d.key}
                 type="button"
                 onClick={() => setDealType(d.key)}
-                className={`flex flex-col items-center justify-center p-4 rounded-2xl border-2 transition ${dealType === d.key ? d.color.replace('bg-', 'ring-2 ring-offset-1 ring-') + ' ' + d.color : 'border-gray-200 bg-white'}`}
+                className={`flex flex-col items-center justify-center p-4 rounded-2xl border-2 transition ${
+                  dealType === d.key
+                    ? `${d.color} ring-2 ${d.ring} ring-offset-1`
+                    : 'border-gray-200 bg-white'
+                }`}
               >
                 <span className="text-3xl mb-1">{d.icon}</span>
                 <span className="text-sm font-bold">{d.label}</span>
@@ -124,7 +199,11 @@ export default function AddProduct() {
             {images.map((url, idx) => (
               <div key={idx} className="relative w-20 h-20 rounded-xl overflow-hidden">
                 <img src={url} alt="" className="w-full h-full object-cover" />
-                <button type="button" onClick={() => setImages(images.filter((_, i) => i !== idx))} className="absolute top-1 right-1 bg-black/60 text-white rounded-full p-0.5">
+                <button
+                  type="button"
+                  onClick={() => setImages(images.filter((_, i) => i !== idx))}
+                  className="absolute top-1 right-1 bg-black/60 text-white rounded-full p-0.5"
+                >
                   <X size={12} />
                 </button>
               </div>
@@ -132,6 +211,7 @@ export default function AddProduct() {
             <button
               type="button"
               onClick={() => fileRef.current?.click()}
+              disabled={uploading}
               className="w-20 h-20 flex flex-col items-center justify-center bg-white border-2 border-dashed border-gray-200 rounded-xl text-gray-400 active:bg-gray-50 transition"
             >
               <Camera size={20} />
@@ -143,7 +223,7 @@ export default function AddProduct() {
 
         {/* Title */}
         <div>
-          <Label className="text-sm font-semibold text-gray-900 mb-1.5 block">ชื่อสินค้า</Label>
+          <Label className="text-sm font-semibold text-gray-900 mb-1.5 block">ชื่อสินค้า <span className="text-red-500">*</span></Label>
           <Input value={title} onChange={(e) => setTitle(e.target.value)} required placeholder="เช่น iPhone 14 Pro" className="rounded-xl h-12 bg-white border-gray-200" />
         </div>
 
@@ -158,7 +238,16 @@ export default function AddProduct() {
           <Label className="text-sm font-semibold text-gray-900 mb-2 block">หมวดหมู่</Label>
           <div className="flex flex-wrap gap-2">
             {CATEGORIES.map((c) => (
-              <button key={c} type="button" onClick={() => setCategory(c)} className={`px-4 py-2 rounded-full text-sm font-medium border transition ${category === c ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-600 border-gray-200'}`}>{c}</button>
+              <button
+                key={c}
+                type="button"
+                onClick={() => setCategory(category === c ? '' : c)}
+                className={`px-4 py-2 rounded-full text-sm font-medium border transition ${
+                  category === c ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-600 border-gray-200'
+                }`}
+              >
+                {c}
+              </button>
             ))}
           </div>
         </div>
@@ -168,7 +257,16 @@ export default function AddProduct() {
           <Label className="text-sm font-semibold text-gray-900 mb-2 block">สภาพสินค้า</Label>
           <div className="flex flex-wrap gap-2">
             {CONDITIONS.map((c) => (
-              <button key={c} type="button" onClick={() => setCondition(c)} className={`px-4 py-2 rounded-full text-sm font-medium border transition ${condition === c ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-600 border-gray-200'}`}>{c}</button>
+              <button
+                key={c}
+                type="button"
+                onClick={() => setCondition(condition === c ? '' : c)}
+                className={`px-4 py-2 rounded-full text-sm font-medium border transition ${
+                  condition === c ? 'bg-gray-900 text-white border-gray-900' : 'bg-white text-gray-600 border-gray-200'
+                }`}
+              >
+                {c}
+              </button>
             ))}
           </div>
         </div>
@@ -196,7 +294,7 @@ export default function AddProduct() {
           <input type="checkbox" checked={openToOffers} onChange={(e) => setOpenToOffers(e.target.checked)} className="w-5 h-5 rounded accent-blue-600" />
           <div>
             <p className="text-sm font-semibold text-gray-900">เปิดกว้างทุกข้อเสนอ</p>
-            <p className="text-xs text-gray-500">รับข้อเสนอทุกรูปแบบ</p>
+            <p className="text-xs text-gray-500">รับข้อเสนอทุกรูปแบบ ไม่จำกัด</p>
           </div>
         </label>
 
@@ -204,44 +302,57 @@ export default function AddProduct() {
         <div>
           <Label className="text-sm font-semibold text-gray-900 mb-2 block">อยากได้ (แท็ก)</Label>
           <div className="flex flex-wrap gap-2 mb-2">
-            {wantedTags.filter(Boolean).map((tag, idx) => (
+            {wantedTags.map((tag, idx) => (
               <span key={idx} className="flex items-center gap-1 px-3 py-1.5 bg-purple-50 text-purple-700 rounded-full text-sm font-medium">
                 {tag}
-                <button type="button" onClick={() => setWantedTags(wantedTags.filter((_, i) => i !== idx))}><X size={12} /></button>
+                <button type="button" onClick={() => setWantedTags(wantedTags.filter((_, i) => i !== idx))} className="ml-0.5 active:opacity-60">
+                  <X size={12} />
+                </button>
               </span>
             ))}
           </div>
           <div className="flex gap-2">
             <Input
-              placeholder="พิมพ์แล้วกด Enter"
-              className="rounded-xl bg-white border-gray-200"
+              ref={tagInputRef}
+              value={tagInput}
+              onChange={(e) => setTagInput(e.target.value)}
+              placeholder="พิมพ์แท็ก แล้วกด +"
+              className="rounded-xl bg-white border-gray-200 flex-1"
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {
                   e.preventDefault()
-                  const val = e.currentTarget.value.trim()
-                  if (val && !wantedTags.includes(val)) {
-                    setWantedTags([...wantedTags.filter(Boolean), val])
-                    e.currentTarget.value = ''
-                  }
+                  addTag()
                 }
               }}
             />
+            <button
+              type="button"
+              onClick={addTag}
+              className="w-12 h-10 flex items-center justify-center bg-purple-600 text-white rounded-xl active:opacity-80 transition flex-shrink-0"
+            >
+              <Plus size={18} />
+            </button>
           </div>
         </div>
 
         {/* Wanted description */}
         <div>
           <Label className="text-sm font-semibold text-gray-900 mb-1.5 block">รายละเอียดสิ่งที่อยากได้</Label>
-          <Textarea value={wantedText} onChange={(e) => setWantedText(e.target.value)} placeholder="เช่น อยากได้ MacBook Air M2..." className="rounded-xl bg-white border-gray-200" />
-        </div>
-
-        {/* Submit */}
-        <div className="fixed bottom-0 left-0 right-0 p-4 bg-white border-t border-gray-100 max-w-md mx-auto">
-          <Button type="submit" className="w-full h-14 rounded-2xl bg-blue-600 hover:bg-blue-700 text-base font-bold shadow-lg shadow-blue-600/20 active:scale-[0.98] transition" disabled={createItem.isPending || !title.trim()}>
-            {createItem.isPending ? 'กำลังโพสต์...' : 'โพสต์สินค้า'}
-          </Button>
+          <Textarea value={wantedText} onChange={(e) => setWantedText(e.target.value)} placeholder="เช่น อยากได้ MacBook Air M2 สภาพดี..." className="rounded-xl bg-white border-gray-200" />
         </div>
       </form>
+
+      {/* Fixed submit */}
+      <div className="fixed bottom-0 left-0 right-0 p-4 bg-white border-t border-gray-100 max-w-md mx-auto z-40">
+        <Button
+          type="button"
+          onClick={submit as any}
+          className="w-full h-14 rounded-2xl bg-blue-600 hover:bg-blue-700 text-base font-bold shadow-lg shadow-blue-600/20 active:opacity-90 transition"
+          disabled={isPending || !title.trim()}
+        >
+          {isPending ? (editId ? 'กำลังบันทึก...' : 'กำลังโพสต์...') : (editId ? 'บันทึกการแก้ไข' : 'โพสต์สินค้า')}
+        </Button>
+      </div>
     </div>
   )
 }

--- a/src/pages/EditProfile.tsx
+++ b/src/pages/EditProfile.tsx
@@ -12,7 +12,14 @@ export default function EditProfile() {
   const navigate = useNavigate()
   const { user, refetch } = useAuth()
   const { data: me } = trpc.profile.me.useQuery(undefined, { enabled: !!user })
-  const update = trpc.profile.updateMe.useMutation({ onSuccess: () => { refetch(); navigate('/profile') } })
+  const utils = trpc.useContext()
+  const update = trpc.profile.updateMe.useMutation({
+    onSuccess: () => {
+      utils.profile.me.invalidate()
+      refetch()
+      navigate('/profile')
+    },
+  })
 
   const [displayName, setDisplayName] = useState('')
   const [username, setUsername] = useState('')

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -21,8 +21,14 @@ export default function Feed() {
   const [activeTab, setActiveTab] = useState('all')
   const [filters, setFilters] = useState<Record<string, any>>({})
 
+  const tabFilters = useMemo(() => {
+    if (activeTab === 'following') return { following: true }
+    if (activeTab === 'fast') return { fastResponder: true }
+    return {}
+  }, [activeTab])
+
   const { data: items, isLoading } = trpc.item.list.useQuery(
-    { status: 'active', q: search || undefined, ...filters, limit: 50, offset: 0 },
+    { status: 'active', q: search || undefined, ...tabFilters, ...filters, limit: 50, offset: 0 },
     { enabled: true }
   )
 
@@ -67,6 +73,9 @@ export default function Feed() {
             className="relative w-11 h-11 flex items-center justify-center rounded-full border border-gray-200 active:bg-gray-50"
           >
             <SlidersHorizontal size={18} className="text-gray-600" />
+            {Object.keys(filters).length > 0 && (
+              <span className="absolute top-1 right-1 w-2 h-2 bg-blue-600 rounded-full" />
+            )}
           </button>
         </div>
 
@@ -85,9 +94,6 @@ export default function Feed() {
               {tab.label}
             </button>
           ))}
-          <button className="flex-shrink-0 px-4 py-1.5 rounded-full text-sm font-medium bg-gray-100 text-gray-600">
-            ทุกหมวด
-          </button>
         </div>
       </div>
 
@@ -107,14 +113,14 @@ export default function Feed() {
         {(items || []).map((it: any) => (
           <div
             key={it.id}
-            className="bg-white rounded-2xl border border-gray-100 overflow-hidden active:scale-[0.99] transition-transform shadow-sm"
+            className="bg-white rounded-2xl border border-gray-100 overflow-hidden shadow-sm cursor-pointer select-none"
             onClick={() => navigate(`/item/${it.id}`)}
           >
             {/* Image section with overlays */}
             <div className="relative">
               <div className="w-full aspect-[4/3] bg-gray-100">
                 {it.images?.[0]?.url ? (
-                  <img src={it.images[0].url} alt="" className="w-full h-full object-cover" />
+                  <img src={it.images[0].url} alt={it.title} className="w-full h-full object-cover" loading="lazy" />
                 ) : (
                   <div className="w-full h-full flex items-center justify-center text-gray-300 text-sm">ไม่มีรูป</div>
                 )}
@@ -122,16 +128,16 @@ export default function Feed() {
 
               {/* Overlay pills */}
               <div className="absolute top-3 left-3 right-3 flex justify-between items-start">
-                <span className="px-3 py-1 bg-white/90 backdrop-blur-sm rounded-full text-xs font-semibold text-gray-700">
+                <span className="px-3 py-1 bg-white/90 rounded-full text-xs font-semibold text-gray-700">
                   มืออยู่
                 </span>
                 <div className="flex items-center gap-2">
-                  <span className="px-3 py-1 bg-white/90 backdrop-blur-sm rounded-full text-xs font-medium text-gray-700">
+                  <span className="px-3 py-1 bg-white/90 rounded-full text-xs font-medium text-gray-700">
                     อยากได้ · {it.openToOffers ? 'เปิดรับข้อเสนอ' : it.wantedTags?.[0] || 'แลกได้'}
                   </span>
                   <button
                     onClick={(e) => toggleBookmark(e, it.id)}
-                    className="w-8 h-8 flex items-center justify-center rounded-full bg-white/90 backdrop-blur-sm active:scale-90 transition"
+                    className="w-8 h-8 flex items-center justify-center rounded-full bg-white/90 active:opacity-70 transition-opacity"
                   >
                     {bookmarkIds.has(it.id) ? (
                       <BookmarkCheck size={16} className="text-blue-600" />
@@ -149,7 +155,7 @@ export default function Feed() {
                   if (!user) { navigate('/login'); return }
                   navigate(`/item/${it.id}`)
                 }}
-                className="absolute bottom-3 left-1/2 -translate-x-1/2 flex items-center gap-2 px-5 py-2.5 bg-gray-900/80 backdrop-blur-sm text-white rounded-full text-sm font-semibold active:scale-95 transition"
+                className="absolute bottom-3 left-1/2 -translate-x-1/2 flex items-center gap-2 px-5 py-2.5 bg-gray-900/80 text-white rounded-full text-sm font-semibold active:opacity-80 transition-opacity"
               >
                 <Bell size={14} />
                 ข้อเสนอ
@@ -171,11 +177,23 @@ export default function Feed() {
                 </span>
               </div>
 
-              {/* Latest offers section */}
-              <div className="mt-3 pt-3 border-t border-gray-50">
-                <p className="text-xs text-gray-400">ข้อเสนอล่าสุด</p>
-                <p className="text-xs text-gray-500 mt-1">ยังไม่มีข้อเสนอ</p>
-              </div>
+              {/* Wanted tags */}
+              {it.wantedTags && it.wantedTags.length > 0 && (
+                <div className="flex flex-wrap gap-1 mt-2">
+                  {it.wantedTags.slice(0, 3).map((tag: string) => (
+                    <span
+                      key={tag}
+                      className="px-2 py-0.5 bg-purple-50 text-purple-700 rounded-full text-[10px] font-medium"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        navigate(`/shop?wantedTag=${encodeURIComponent(tag)}`)
+                      }}
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         ))}

--- a/src/pages/Inbox.tsx
+++ b/src/pages/Inbox.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router'
 import { trpc } from '@/providers/trpc'
 import { useAuth } from '@/hooks/useAuth'
 import { Button } from '@/components/ui/button'
-import { Check, X, Ban, CheckCircle, ArrowLeft, Inbox as InboxIcon } from 'lucide-react'
+import { Check, X, Ban, CheckCircle, Inbox as InboxIcon, Package } from 'lucide-react'
 
 export default function Inbox() {
   const navigate = useNavigate()
@@ -42,19 +42,22 @@ export default function Inbox() {
 
   return (
     <div className="max-w-md mx-auto min-h-screen bg-gray-50">
-      <div className="sticky top-0 z-40 bg-white border-b border-gray-100 px-4 py-3 flex items-center gap-3">
-        <button onClick={() => navigate(-1)} className="w-10 h-10 flex items-center justify-center rounded-full bg-gray-100 active:bg-gray-200 transition">
-          <ArrowLeft size={20} />
-        </button>
-        <h1 className="text-lg font-bold">ข้อเสนอ</h1>
+      <div className="sticky top-0 z-40 bg-white border-b border-gray-100 px-4 py-3">
+        <h1 className="text-lg font-bold">ข้อเสนอ (Inbox)</h1>
       </div>
 
       <div className="p-4">
         <div className="flex gap-2 mb-4">
-          <button onClick={() => setTab('received')} className={`flex-1 py-2.5 rounded-xl text-sm font-semibold transition ${tab === 'received' ? 'bg-gray-900 text-white' : 'bg-white text-gray-600 border border-gray-200'}`}>
+          <button
+            onClick={() => setTab('received')}
+            className={`flex-1 py-2.5 rounded-xl text-sm font-semibold transition ${tab === 'received' ? 'bg-gray-900 text-white' : 'bg-white text-gray-600 border border-gray-200'}`}
+          >
             ได้รับ ({offers?.received?.length || 0})
           </button>
-          <button onClick={() => setTab('sent')} className={`flex-1 py-2.5 rounded-xl text-sm font-semibold transition ${tab === 'sent' ? 'bg-gray-900 text-white' : 'bg-white text-gray-600 border border-gray-200'}`}>
+          <button
+            onClick={() => setTab('sent')}
+            className={`flex-1 py-2.5 rounded-xl text-sm font-semibold transition ${tab === 'sent' ? 'bg-gray-900 text-white' : 'bg-white text-gray-600 border border-gray-200'}`}
+          >
             ส่งแล้ว ({offers?.sent?.length || 0})
           </button>
         </div>
@@ -65,37 +68,87 @@ export default function Inbox() {
             <p className="text-gray-400 text-sm">ไม่มีข้อเสนอ</p>
           </div>
         )}
-        <div className="space-y-3">
+
+        <div className="space-y-3 pb-24">
           {list.map((o: any) => (
             <div key={o.id} className="bg-white rounded-2xl border border-gray-100 p-4">
-              <div className="flex items-center justify-between mb-2">
+              {/* Status + date */}
+              <div className="flex items-center justify-between mb-3">
                 {statusBadge(o.status)}
                 <span className="text-xs text-gray-400">{new Date(o.createdAt).toLocaleDateString('th-TH')}</span>
               </div>
-              <p className="text-sm text-gray-700 font-medium mb-1">{o.message || 'ไม่มีข้อความ'}</p>
-              <div className="text-xs text-gray-500 mb-3">
-                {o.cashAmount ? `เงินสด ${o.cashAmount} บาท ` : ''}
-                {o.creditAmount ? `เครดิต ${o.creditAmount}` : ''}
-                {!o.cashAmount && !o.creditAmount && 'ไม่มีเงิน/เครดิต'}
+
+              {/* Target item link */}
+              {o.targetItemId && (
+                <button
+                  onClick={() => navigate(`/item/${o.targetItemId}`)}
+                  className="w-full flex items-center gap-2 bg-gray-50 rounded-xl p-2.5 mb-3 text-left active:bg-gray-100 transition"
+                >
+                  <Package size={14} className="text-gray-400 flex-shrink-0" />
+                  <span className="text-xs text-gray-600 truncate">สินค้า: {o.targetItemId}</span>
+                </button>
+              )}
+
+              {/* Offer details */}
+              {o.message && (
+                <p className="text-sm text-gray-700 font-medium mb-2 leading-relaxed">{o.message}</p>
+              )}
+              <div className="text-xs text-gray-500 mb-3 flex flex-wrap gap-2">
+                {o.cashAmount > 0 && (
+                  <span className="px-2 py-0.5 bg-green-50 text-green-700 rounded-full font-medium">
+                    เงินสด {o.cashAmount.toLocaleString()} บาท
+                  </span>
+                )}
+                {o.creditAmount > 0 && (
+                  <span className="px-2 py-0.5 bg-blue-50 text-blue-700 rounded-full font-medium">
+                    เครดิต {o.creditAmount.toLocaleString()}
+                  </span>
+                )}
+                {!o.cashAmount && !o.creditAmount && !o.message && (
+                  <span className="text-gray-400">ไม่มีรายละเอียดเพิ่มเติม</span>
+                )}
               </div>
 
+              {/* Actions */}
               {tab === 'received' && o.status === 'pending' && (
                 <div className="flex gap-2">
-                  <Button size="sm" className="flex-1 rounded-xl bg-green-600 hover:bg-green-700 h-10 font-semibold" onClick={() => accept.mutate({ id: o.id })}>
+                  <Button
+                    size="sm"
+                    className="flex-1 rounded-xl bg-green-600 hover:bg-green-700 h-10 font-semibold"
+                    onClick={() => accept.mutate({ id: o.id })}
+                    disabled={accept.isPending}
+                  >
                     <Check size={14} className="mr-1" /> ตอบรับ
                   </Button>
-                  <Button size="sm" variant="outline" className="flex-1 rounded-xl h-10 font-semibold" onClick={() => reject.mutate({ id: o.id })}>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="flex-1 rounded-xl h-10 font-semibold"
+                    onClick={() => reject.mutate({ id: o.id })}
+                    disabled={reject.isPending}
+                  >
                     <X size={14} className="mr-1" /> ปฏิเสธ
                   </Button>
                 </div>
               )}
               {tab === 'sent' && o.status === 'pending' && (
-                <Button size="sm" variant="outline" className="rounded-xl h-10 font-semibold" onClick={() => cancel.mutate({ id: o.id })}>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="rounded-xl h-10 font-semibold text-red-500 border-red-200 hover:bg-red-50"
+                  onClick={() => cancel.mutate({ id: o.id })}
+                  disabled={cancel.isPending}
+                >
                   <Ban size={14} className="mr-1" /> ยกเลิก
                 </Button>
               )}
               {tab === 'received' && o.status === 'accepted' && (
-                <Button size="sm" className="rounded-xl bg-blue-600 hover:bg-blue-700 h-10 font-semibold" onClick={() => confirm.mutate({ id: o.id })}>
+                <Button
+                  size="sm"
+                  className="rounded-xl bg-blue-600 hover:bg-blue-700 h-10 font-semibold"
+                  onClick={() => confirm.mutate({ id: o.id })}
+                  disabled={confirm.isPending}
+                >
                   <CheckCircle size={14} className="mr-1" /> ยืนยัน
                 </Button>
               )}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Eye, EyeOff } from 'lucide-react'
+import { trpc } from '@/providers/trpc'
 
 export default function Login() {
   const [mode, setMode] = useState<'login' | 'signup'>('login')
@@ -13,6 +14,7 @@ export default function Login() {
   const [error, setError] = useState('')
   const { login, signup } = useAuth()
   const navigate = useNavigate()
+  const utils = trpc.useContext()
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -23,6 +25,8 @@ export default function Login() {
       } else {
         await signup(email, password)
       }
+      utils.item.list.invalidate()
+      utils.item.feed.invalidate()
       navigate('/')
     } catch (err: any) {
       setError(err.message || 'เกิดข้อผิดพลาด')

--- a/src/pages/Shop.tsx
+++ b/src/pages/Shop.tsx
@@ -3,23 +3,26 @@ import { useNavigate, useSearchParams } from 'react-router'
 import { trpc } from '@/providers/trpc'
 import { useAuth } from '@/hooks/useAuth'
 import { Input } from '@/components/ui/input'
-import { Search, Bookmark, BookmarkCheck } from 'lucide-react'
+import { Search, SlidersHorizontal, Bookmark, BookmarkCheck } from 'lucide-react'
+import FilterSheet from '@/components/FilterSheet'
 
 const SHOP_TABS = [
-  { key: 'all', label: 'ทั้งหมด' },
-  { key: 'buy', label: 'ซื้อได้เลย' },
-  { key: 'xwap', label: 'Xwap ได้' },
+  { key: 'all', label: 'ทั้งหมด', dealType: undefined },
+  { key: 'buy', label: 'ซื้อได้เลย', dealType: 'sell' },
+  { key: 'xwap', label: 'Xwap ได้', dealType: 'swap' },
 ]
 
 const CATEGORIES = [
   { name: 'ทั้งหมด', icon: '🔍' },
-  { name: 'แม่และเด็ก', icon: '🍼' },
   { name: 'Gadget', icon: '⌚' },
-  { name: 'เสื้อผ้า', icon: '👕' },
-  { name: 'กีฬา', icon: '⚽' },
-  { name: 'บ้าน', icon: '🏠' },
-  { name: 'หนังสือ', icon: '📚' },
-  { name: 'ความงาม', icon: '💄' },
+  { name: 'Fashion', icon: '👕' },
+  { name: 'Sports', icon: '⚽' },
+  { name: 'Home', icon: '🏠' },
+  { name: 'Books', icon: '📚' },
+  { name: 'Beauty', icon: '💄' },
+  { name: 'Electronics', icon: '💻' },
+  { name: 'Toys', icon: '🧸' },
+  { name: 'Other', icon: '📦' },
 ]
 
 export default function Shop() {
@@ -29,20 +32,28 @@ export default function Shop() {
   const [search, setSearch] = useState('')
   const [activeTab, setActiveTab] = useState('all')
   const [activeCategory, setActiveCategory] = useState('ทั้งหมด')
+  const [showFilter, setShowFilter] = useState(false)
   const [filters, setFilters] = useState<Record<string, any>>({})
 
   const wantedTagFromUrl = searchParams.get('wantedTag')
 
   useEffect(() => {
     if (wantedTagFromUrl) {
-      setFilters((prev: Record<string, any>) => ({ ...prev, wantedTag: wantedTagFromUrl }))
+      setFilters((prev) => ({ ...prev, wantedTag: wantedTagFromUrl }))
     }
   }, [wantedTagFromUrl])
+
+  const tabDealType = useMemo(() => {
+    return SHOP_TABS.find((t) => t.key === activeTab)?.dealType
+  }, [activeTab])
+
+  const categoryFilter = activeCategory !== 'ทั้งหมด' ? activeCategory : undefined
 
   const { data, isLoading } = trpc.item.list.useQuery(
     {
       q: search || undefined,
-      category: activeCategory !== 'ทั้งหมด' ? activeCategory : undefined,
+      category: categoryFilter,
+      dealType: tabDealType,
       ...filters,
       limit: 50,
     },
@@ -71,14 +82,22 @@ export default function Shop() {
     }
   }
 
+  const activeFilterCount = Object.keys(filters).length + (wantedTagFromUrl ? 1 : 0)
+
   return (
     <div className="max-w-md mx-auto">
       {/* Header */}
       <div className="sticky top-0 z-40 bg-white border-b border-gray-100 px-4 pt-3 pb-2">
         <div className="flex items-center justify-between mb-3">
           <h1 className="text-2xl font-black text-gray-900 tracking-tight">สินค้าทั้งหมด</h1>
-          <button className="w-10 h-10 flex items-center justify-center rounded-full border border-gray-200 active:bg-gray-50">
-            <Search size={18} className="text-gray-600" />
+          <button
+            onClick={() => setShowFilter(true)}
+            className="relative w-10 h-10 flex items-center justify-center rounded-full border border-gray-200 active:bg-gray-50"
+          >
+            <SlidersHorizontal size={18} className="text-gray-600" />
+            {activeFilterCount > 0 && (
+              <span className="absolute top-1 right-1 w-2 h-2 bg-blue-600 rounded-full" />
+            )}
           </button>
         </div>
 
@@ -113,13 +132,12 @@ export default function Shop() {
 
       {/* Category horizontal scroll */}
       <div className="px-4 pt-4 pb-2">
-        <h2 className="text-lg font-bold text-gray-900 mb-3">หมวดหมู่</h2>
         <div className="flex gap-3 overflow-x-auto scrollbar-hide pb-2">
           {CATEGORIES.map((cat) => (
             <button
               key={cat.name}
               onClick={() => setActiveCategory(cat.name)}
-              className={`flex-shrink-0 flex flex-col items-center gap-2 px-4 py-3 rounded-2xl border transition min-w-[72px] ${
+              className={`flex-shrink-0 flex flex-col items-center gap-1.5 px-4 py-3 rounded-2xl border transition min-w-[68px] ${
                 activeCategory === cat.name
                   ? 'bg-blue-50 border-blue-200'
                   : 'bg-white border-gray-100'
@@ -132,6 +150,24 @@ export default function Shop() {
         </div>
       </div>
 
+      {/* Wanted tag chip */}
+      {wantedTagFromUrl && (
+        <div className="px-4 pb-2 flex items-center gap-2">
+          <span className="px-3 py-1 bg-purple-50 text-purple-700 rounded-full text-xs font-medium">
+            อยากได้: {wantedTagFromUrl}
+          </span>
+          <button
+            onClick={() => {
+              setFilters((prev) => { const f = { ...prev }; delete f.wantedTag; return f })
+              navigate('/shop', { replace: true })
+            }}
+            className="text-gray-400 active:opacity-60"
+          >
+            <span className="text-xs">✕ ล้าง</span>
+          </button>
+        </div>
+      )}
+
       {/* Product grid */}
       <div className="px-4 pb-24">
         {isLoading && <div className="text-center py-10 text-gray-400 text-sm">กำลังโหลด...</div>}
@@ -142,26 +178,26 @@ export default function Shop() {
           {items.map((it: any) => (
             <div
               key={it.id}
-              className="bg-white rounded-2xl border border-gray-100 overflow-hidden active:scale-[0.98] transition-transform shadow-sm"
+              className="bg-white rounded-2xl border border-gray-100 overflow-hidden shadow-sm cursor-pointer select-none"
               onClick={() => navigate(`/item/${it.id}`)}
             >
               {/* Image */}
               <div className="relative">
                 <div className="w-full aspect-square bg-gray-100">
                   {it.images?.[0]?.url ? (
-                    <img src={it.images[0].url} alt="" className="w-full h-full object-cover" />
+                    <img src={it.images[0].url} alt={it.title} className="w-full h-full object-cover" loading="lazy" />
                   ) : (
                     <div className="w-full h-full flex items-center justify-center text-gray-300 text-xs">ไม่มีรูป</div>
                   )}
                 </div>
-                {/* Swap badge */}
+                {/* Deal badge */}
                 <span className="absolute top-2 left-2 px-2 py-0.5 bg-black/70 text-white text-[10px] font-medium rounded-full">
-                  แลกได้
+                  {it.dealType === 'swap' ? 'แลก' : it.dealType === 'sell' ? 'ขาย' : it.dealType === 'buy' ? 'ต้องการซื้อ' : 'ขาย/แลก'}
                 </span>
                 {/* Bookmark */}
                 <button
                   onClick={(e) => toggleBookmark(e, it.id)}
-                  className="absolute top-2 right-2 w-7 h-7 flex items-center justify-center rounded-full bg-white/90 backdrop-blur-sm active:scale-90 transition"
+                  className="absolute top-2 right-2 w-7 h-7 flex items-center justify-center rounded-full bg-white/90 active:opacity-70 transition-opacity"
                 >
                   {bookmarkIds.has(it.id) ? (
                     <BookmarkCheck size={14} className="text-blue-600" />
@@ -201,6 +237,13 @@ export default function Shop() {
           ))}
         </div>
       </div>
+
+      <FilterSheet
+        open={showFilter}
+        onClose={() => setShowFilter(false)}
+        onApply={setFilters}
+        initialFilters={filters}
+      />
     </div>
   )
 }

--- a/src/providers/trpc.tsx
+++ b/src/providers/trpc.tsx
@@ -10,8 +10,9 @@ export const trpc = createTRPCReact<AppRouter>();
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 60 * 1000,
+      staleTime: 5 * 60 * 1000,
       retry: 1,
+      refetchOnWindowFocus: false,
     },
   },
 });


### PR DESCRIPTION
- EditProfile: invalidate profile.me query after update so avatar persists on Profile page
- Login: invalidate item queries after login/signup so Feed shows items immediately without refresh
- trpc: disable refetchOnWindowFocus and increase staleTime to 5min to prevent jump-reloads
- Feed: connect Following/Fast tabs to actual query filters; show wantedTags on cards; remove scale transforms that caused scroll jank; add filter active indicator
- Shop: connect Buy/Xwap tabs to dealType filter; add FilterSheet with filter indicator; proper deal badge; remove scale transforms; show wantedTag URL param chip with clear button
- AddProduct: full edit mode via ?edit=id URL param — loads existing item, pre-fills form, submits update mutation; + button for wantedTags on mobile; redirect to item after create/update; invalidate caches
- OfferSheet: add validation (must have message/cash/credit or items); better error display; flex layout so content scrolls on mobile; only fetch myItems when sheet is open
- FilterSheet: flex layout with overflow-y-auto for reliable mobile scroll
- Inbox: styled offer cards with target item navigation button, styled cash/credit badges, disabled states on action buttons

https://claude.ai/code/session_01XKpggNmdQvGc5g8FK83o8w