### PR TITLE
fix: use createServer+getRequestListener, fix PORT in render.yaml and CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
           node dist/boot.js &
           SERVER_PID=$!
           sleep 8
-          curl -f http://localhost:3000/api/health \
+          curl -f http://localhost:10000/api/health \
             && kill $SERVER_PID \
             || (kill $SERVER_PID 2>/dev/null; exit 1)
 

--- a/api/boot.ts
+++ b/api/boot.ts
@@ -84,13 +84,15 @@ app.all("/api/*", (c) => c.json({ error: "Not Found" }, 404));
 export default app;
 
 if (env.isProduction) {
-  const { serve } = await import("@hono/node-server");
+  const { createServer } = await import("node:http");
+  const { getRequestListener } = await import("@hono/node-server");
   const { serveStaticFiles } = await import("./lib/vite");
   serveStaticFiles(app);
 
   const port = Number(process.env.PORT || 10000);
   const host = "0.0.0.0";
-  serve({ fetch: app.fetch, port, hostname: host }, () => {
+  const server = createServer(getRequestListener(app.fetch));
+  server.listen(port, host, () => {
     console.log(`Server running on http://${host}:${port}/`);
   });
 }

--- a/render.yaml
+++ b/render.yaml
@@ -14,8 +14,6 @@ services:
     envVars:
       - key: NODE_VERSION
         value: "20"
-      - key: PORT
-        value: 3000
       - key: DATABASE_URL
         fromDatabase:
           name: qxwap-db


### PR DESCRIPTION
- Replace serve() with explicit createServer(getRequestListener(app.fetch)) and server.listen(port, "0.0.0.0", cb) — identical to the pattern requested; removes any ambiguity around how @hono/node-server forwards the hostname option
- Remove hardcoded PORT=3000 from render.yaml so Render's platform default (10000) is used without conflict
- Fix CI health-check curl from localhost:3000 → localhost:10000 to match the server's actual default port

https://claude.ai/code/session_01QvuRKbxrRmTFVisSjvuWLj