### PR TITLE
Fix production API base resolution and cross-origin auth cookies/CORS

### DIFF
--- a/api/boot.ts
+++ b/api/boot.ts
@@ -17,8 +17,10 @@ const DB_HEALTH_TIMEOUT_MS = 3000;
 app.get("/api/health", (c) => c.json({ ok: true }));
 
 app.use(cors({
-  origin: env.isProduction ? (process.env.FRONTEND_ORIGIN || "") : "http://localhost:3000",
+  origin: env.isProduction ? (process.env.FRONTEND_ORIGIN || "https://aswer1840.github.io") : "http://localhost:3000",
   credentials: true,
+  allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+  allowHeaders: ["Content-Type", "Authorization"],
 }));
 
 const UPLOAD_DIR = path.join(process.cwd(), "uploads");

--- a/api/routes/auth.ts
+++ b/api/routes/auth.ts
@@ -3,10 +3,20 @@ import { getDb } from "../queries/connection";
 import { users, profiles, wallets } from "@db/schema";
 import { eq } from "drizzle-orm";
 import { createSession, destroySession, getSession, serializeCookie, parseCookies } from "../lib/session";
+import { env } from "../lib/env";
 
 const auth = new Hono();
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 type AuthStatus = 400 | 401 | 404 | 409 | 500;
+
+function sessionCookieOptions(maxAge: number) {
+  return {
+    httpOnly: true,
+    sameSite: env.isProduction ? "None" : "Lax",
+    secure: env.isProduction,
+    maxAge,
+  };
+}
 
 function jsonError(c: Context, message: string, status: AuthStatus = 400) {
   return c.json({ success: false, message, error: message }, status);
@@ -46,7 +56,7 @@ async function signupHandler(c: Context) {
   await db.insert(wallets).values({ userId, creditBalance: 0 }).onConflictDoNothing();
 
   const sid = await createSession({ userId, email });
-  c.header("Set-Cookie", serializeCookie("sid", sid, { httpOnly: true, sameSite: "Lax", maxAge: 7 * 24 * 60 * 60 }));
+  c.header("Set-Cookie", serializeCookie("sid", sid, sessionCookieOptions(7 * 24 * 60 * 60)));
   return c.json({ success: true, message: "register success", user: { id: userId, email, profile: null } });
 }
 
@@ -67,7 +77,7 @@ async function signinHandler(c: Context) {
   if (!valid) return jsonError(c, "Invalid email or password", 401);
 
   const sid = await createSession({ userId: user.id, email: user.email });
-  c.header("Set-Cookie", serializeCookie("sid", sid, { httpOnly: true, sameSite: "Lax", maxAge: 7 * 24 * 60 * 60 }));
+  c.header("Set-Cookie", serializeCookie("sid", sid, sessionCookieOptions(7 * 24 * 60 * 60)));
   return c.json({ success: true, message: "login success", user: { id: user.id, email: user.email, profile: null } });
 }
 
@@ -81,7 +91,7 @@ auth.post("/signout", async (c) => {
   const cookies = parseCookies(c.req.header("cookie") || "");
   const sid = cookies["sid"];
   if (sid) await destroySession(sid);
-  c.header("Set-Cookie", serializeCookie("sid", "", { httpOnly: true, sameSite: "Lax", maxAge: 0 }));
+  c.header("Set-Cookie", serializeCookie("sid", "", sessionCookieOptions(0)));
   return c.json({ success: true, message: "logout success" });
 });
 
@@ -91,7 +101,7 @@ auth.get("/me", async (c) => {
   if (!sid) return c.json({ success: true, user: null });
   const session = await getSession(sid);
   if (!session) {
-    c.header("Set-Cookie", serializeCookie("sid", "", { httpOnly: true, sameSite: "Lax", maxAge: 0 }));
+    c.header("Set-Cookie", serializeCookie("sid", "", sessionCookieOptions(0)));
     return c.json({ success: true, user: null });
   }
   const db = await getDb();

--- a/src/lib/apiBase.ts
+++ b/src/lib/apiBase.ts
@@ -1,0 +1,21 @@
+const PROD_API_BASE = "https://qxwap-api.onrender.com/api";
+
+function getWindowApiBase() {
+  if (typeof window === "undefined") return "";
+  const value = (window as Window & { API_BASE?: unknown }).API_BASE;
+  return typeof value === "string" ? value : "";
+}
+
+export function resolveApiBase() {
+  const configured =
+    getWindowApiBase() ||
+    import.meta.env.VITE_API_BASE ||
+    import.meta.env.VITE_API_URL ||
+    "";
+
+  const trimmed = configured.replace(/\/+$/, "");
+  if (trimmed) return trimmed;
+
+  return import.meta.env.PROD ? PROD_API_BASE : "/api";
+}
+

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,4 +1,6 @@
-const API_BASE_URL = (import.meta.env.VITE_API_URL || "").replace(/\/$/, "");
+import { resolveApiBase } from "@/lib/apiBase";
+
+const API_BASE_URL = resolveApiBase();
 
 export class ApiClientError extends Error {
   status?: number;

--- a/src/providers/trpc.tsx
+++ b/src/providers/trpc.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import superjson from "superjson";
 import type { AppRouter } from "../../api/router";
 import type { ReactNode } from "react";
+import { resolveApiBase } from "@/lib/apiBase";
 
 export const trpc = createTRPCReact<AppRouter>();
 
@@ -17,15 +18,10 @@ const queryClient = new QueryClient({
   },
 });
 
-function getApiBase() {
-  const base = (typeof window !== "undefined" && (window as any).API_BASE) || import.meta.env.VITE_API_BASE || "/api";
-  return base.replace(/\/+$/, "");
-}
-
 const trpcClient = trpc.createClient({
   links: [
     httpLink({
-      url: `${getApiBase()}/trpc`,
+      url: `${resolveApiBase()}/trpc`,
       transformer: superjson,
       fetch(input, init) {
         return globalThis.fetch(input, {


### PR DESCRIPTION
### Motivation
- Production frontend could resolve an incorrect API base (e.g. pointing at the GitHub Pages host) causing "Failed to fetch" and broken auth flows across domains.  
- Cookies/sessions and CORS were not fully configured for credentialed cross-site requests between the GitHub Pages frontend and the Render backend.

### Description
- Added a shared API base resolver `resolveApiBase()` that chooses `window.API_BASE` → `VITE_API_BASE` → `VITE_API_URL` → production fallback `https://qxwap-api.onrender.com/api` → dev fallback `/api` in `src/lib/apiBase.ts`.  
- Updated REST client to use the resolver in `src/lib/apiClient.ts` and tRPC client to use it in `src/providers/trpc.tsx`.  
- Tightened backend CORS and defaults in `api/boot.ts` to allow credentials with explicit methods and headers and a production default origin of `https://aswer1840.github.io`.  
- Updated auth cookie settings in `api/routes/auth.ts` to emit `SameSite=None; Secure` in production so cross-site cookies work with `credentials: include`, and centralized cookie options helper was added.

Files changed: `src/lib/apiBase.ts` (new), `src/lib/apiClient.ts`, `src/providers/trpc.tsx`, `api/boot.ts`, `api/routes/auth.ts`.

Production endpoints discovered and confirmed in code: `POST /api/auth/signup` (alias `/register`), `POST /api/auth/signin` (alias `/login`), `GET /api/auth/me`, `POST /api/auth/signout`.

### Testing
- Ran `npm run check` which completed successfully.  
- Ran `npm test` (Vitest) and all tests passed.  
- Ran `npm run build` and the Vite production build plus server build completed successfully; CI/deploy workflow already injects `VITE_API_BASE` with default `https://qxwap-api.onrender.com/api`.  
- Attempted `curl` to `https://qxwap-api.onrender.com/api/health` and CORS/OPTIONS checks but this execution environment could not reach the Render host (network/HTTP tunnel blocked), so live production health and full register/login verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7692aab7483228568287a504bfac2)