### PR TITLE
Centralize API base resolution, tighten CORS and session cookie handling, and add production auth test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,7 @@ jobs:
           NODE_ENV: production
           DATABASE_URL: ./data/ci-db
           SESSION_SECRET: ci-health-check-secret-32chars-ok
+          PORT: 3000
         run: |
           mkdir -p ./data/ci-db
           node dist/boot.js &

--- a/api/boot.ts
+++ b/api/boot.ts
@@ -17,8 +17,10 @@ const DB_HEALTH_TIMEOUT_MS = 3000;
 app.get("/api/health", (c) => c.json({ ok: true }));
 
 app.use(cors({
-  origin: env.isProduction ? (process.env.FRONTEND_ORIGIN || "") : "http://localhost:3000",
+  origin: env.isProduction ? (process.env.FRONTEND_ORIGIN || "https://aswer1840.github.io") : "http://localhost:3000",
   credentials: true,
+  allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+  allowHeaders: ["Content-Type", "Authorization"],
 }));
 
 const UPLOAD_DIR = path.join(process.cwd(), "uploads");

--- a/api/routes/auth.ts
+++ b/api/routes/auth.ts
@@ -3,10 +3,20 @@ import { getDb } from "../queries/connection";
 import { users, profiles, wallets } from "@db/schema";
 import { eq } from "drizzle-orm";
 import { createSession, destroySession, getSession, serializeCookie, parseCookies } from "../lib/session";
+import { env } from "../lib/env";
 
 const auth = new Hono();
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 type AuthStatus = 400 | 401 | 404 | 409 | 500;
+
+function sessionCookieOptions(maxAge: number) {
+  return {
+    httpOnly: true,
+    sameSite: env.isProduction ? "None" : "Lax",
+    secure: env.isProduction,
+    maxAge,
+  };
+}
 
 function jsonError(c: Context, message: string, status: AuthStatus = 400) {
   return c.json({ success: false, message, error: message }, status);
@@ -46,7 +56,7 @@ async function signupHandler(c: Context) {
   await db.insert(wallets).values({ userId, creditBalance: 0 }).onConflictDoNothing();
 
   const sid = await createSession({ userId, email });
-  c.header("Set-Cookie", serializeCookie("sid", sid, { httpOnly: true, sameSite: "Lax", maxAge: 7 * 24 * 60 * 60 }));
+  c.header("Set-Cookie", serializeCookie("sid", sid, sessionCookieOptions(7 * 24 * 60 * 60)));
   return c.json({ success: true, message: "register success", user: { id: userId, email, profile: null } });
 }
 
@@ -67,7 +77,7 @@ async function signinHandler(c: Context) {
   if (!valid) return jsonError(c, "Invalid email or password", 401);
 
   const sid = await createSession({ userId: user.id, email: user.email });
-  c.header("Set-Cookie", serializeCookie("sid", sid, { httpOnly: true, sameSite: "Lax", maxAge: 7 * 24 * 60 * 60 }));
+  c.header("Set-Cookie", serializeCookie("sid", sid, sessionCookieOptions(7 * 24 * 60 * 60)));
   return c.json({ success: true, message: "login success", user: { id: user.id, email: user.email, profile: null } });
 }
 
@@ -81,7 +91,7 @@ auth.post("/signout", async (c) => {
   const cookies = parseCookies(c.req.header("cookie") || "");
   const sid = cookies["sid"];
   if (sid) await destroySession(sid);
-  c.header("Set-Cookie", serializeCookie("sid", "", { httpOnly: true, sameSite: "Lax", maxAge: 0 }));
+  c.header("Set-Cookie", serializeCookie("sid", "", sessionCookieOptions(0)));
   return c.json({ success: true, message: "logout success" });
 });
 
@@ -91,7 +101,7 @@ auth.get("/me", async (c) => {
   if (!sid) return c.json({ success: true, user: null });
   const session = await getSession(sid);
   if (!session) {
-    c.header("Set-Cookie", serializeCookie("sid", "", { httpOnly: true, sameSite: "Lax", maxAge: 0 }));
+    c.header("Set-Cookie", serializeCookie("sid", "", sessionCookieOptions(0)));
     return c.json({ success: true, user: null });
   }
   const db = await getDb();

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test": "vitest run",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test:prod:auth": "bash scripts/test-production-auth.sh"
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.4.5",

--- a/scripts/test-production-auth.sh
+++ b/scripts/test-production-auth.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_BASE="${1:-https://qxwap-api.onrender.com/api}"
+FRONTEND_ORIGIN="${2:-https://aswer1840.github.io}"
+TS="$(date +%s)"
+EMAIL="qxwap.test+${TS}@gmail.com"
+PASSWORD="Test123456!"
+JAR="$(mktemp)"
+
+cleanup(){ rm -f "$JAR"; }
+trap cleanup EXIT
+
+echo "[1/5] health"
+curl -fsS -i "$API_BASE/health"
+
+echo "[2/5] cors preflight"
+curl -fsS -i -X OPTIONS "$API_BASE/health" \
+  -H "Origin: $FRONTEND_ORIGIN" \
+  -H "Access-Control-Request-Method: POST" \
+  -H "Access-Control-Request-Headers: content-type"
+
+echo "[3/5] register $EMAIL"
+curl -fsS -i -c "$JAR" -X POST "$API_BASE/auth/signup" \
+  -H 'content-type: application/json' \
+  -H "origin: $FRONTEND_ORIGIN" \
+  --data "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}"
+
+echo "[4/5] login"
+curl -fsS -i -c "$JAR" -b "$JAR" -X POST "$API_BASE/auth/signin" \
+  -H 'content-type: application/json' \
+  -H "origin: $FRONTEND_ORIGIN" \
+  --data "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}"
+
+echo "[5/5] me (cookie session)"
+curl -fsS -i -b "$JAR" -H "origin: $FRONTEND_ORIGIN" "$API_BASE/auth/me"
+
+echo "PASS: production auth flow is reachable and session works"

--- a/src/lib/apiBase.ts
+++ b/src/lib/apiBase.ts
@@ -1,0 +1,21 @@
+const PROD_API_BASE = "https://qxwap-api.onrender.com/api";
+
+function getWindowApiBase() {
+  if (typeof window === "undefined") return "";
+  const value = (window as Window & { API_BASE?: unknown }).API_BASE;
+  return typeof value === "string" ? value : "";
+}
+
+export function resolveApiBase() {
+  const configured =
+    getWindowApiBase() ||
+    import.meta.env.VITE_API_BASE ||
+    import.meta.env.VITE_API_URL ||
+    "";
+
+  const trimmed = configured.replace(/\/+$/, "");
+  if (trimmed) return trimmed;
+
+  return import.meta.env.PROD ? PROD_API_BASE : "/api";
+}
+

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,4 +1,6 @@
-const API_BASE_URL = (import.meta.env.VITE_API_URL || "").replace(/\/$/, "");
+import { resolveApiBase } from "@/lib/apiBase";
+
+const API_BASE_URL = resolveApiBase();
 
 export class ApiClientError extends Error {
   status?: number;

--- a/src/providers/trpc.tsx
+++ b/src/providers/trpc.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import superjson from "superjson";
 import type { AppRouter } from "../../api/router";
 import type { ReactNode } from "react";
+import { resolveApiBase } from "@/lib/apiBase";
 
 export const trpc = createTRPCReact<AppRouter>();
 
@@ -17,15 +18,10 @@ const queryClient = new QueryClient({
   },
 });
 
-function getApiBase() {
-  const base = (typeof window !== "undefined" && (window as any).API_BASE) || import.meta.env.VITE_API_BASE || "/api";
-  return base.replace(/\/+$/, "");
-}
-
 const trpcClient = trpc.createClient({
   links: [
     httpLink({
-      url: `${getApiBase()}/trpc`,
+      url: `${resolveApiBase()}/trpc`,
       transformer: superjson,
       fetch(input, init) {
         return globalThis.fetch(input, {


### PR DESCRIPTION
### Motivation

- Ensure the frontend and TRPC client resolve the correct API base URL in both dev and production environments.
- Allow the production GitHub Pages frontend origin by default and enable necessary CORS preflight methods/headers to support cross-origin requests with cookies.
- Standardize session cookie options to respect `env.isProduction` (secure and `SameSite=None`) and provide an automated script to validate the production auth flow.

### Description

- Updated `api/boot.ts` to change the production default `origin` to `https://aswer1840.github.io` and added `allowMethods` and `allowHeaders` to the CORS config.  
- Introduced `sessionCookieOptions` in `api/routes/auth.ts`, imported `env`, and replaced inline cookie option objects with the helper to set `httpOnly`, `sameSite`, `secure`, and `maxAge` consistently.  
- Added `src/lib/apiBase.ts` with `resolveApiBase()` and updated `src/lib/apiClient.ts` and `src/providers/trpc.tsx` to use it so the client and TRPC link compute the API base consistently.  
- Added a production auth test script `scripts/test-production-auth.sh` and exposed it via `package.json` as `test:prod:auth`.  
- Small CI tweak in `.github/workflows/deploy.yml` to set `PORT: 3000` for the backend health verification step.

### Testing

- Ran type checking with `npm run check` (`tsc -b`) in CI and it succeeded.  
- Ran unit tests with `npm test` (`vitest run`) in CI and they succeeded.  
- CI backend health verification executed the booted server and the `/api/health` check succeeded using the added `PORT` environment setting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7692aab7483228568287a504bfac2)