### PR TITLE
Prepare production database startup

### DIFF
--- a/api/queries/connection.ts
+++ b/api/queries/connection.ts
@@ -9,8 +9,8 @@ import * as relations from "@db/relations";
 
 const fullSchema = { ...schema, ...relations };
 
-let instance: ReturnType<typeof drizzle<typeof fullSchema>> | ReturnType<typeof drizzlePg<typeof fullSchema>>;
-let client: PGlite | Pool;
+let instance: ReturnType<typeof drizzle<typeof fullSchema>> | ReturnType<typeof drizzlePg<typeof fullSchema>> | undefined;
+let client: PGlite | Pool | undefined;
 
 export async function getDb() {
   if (!instance) {
@@ -43,4 +43,14 @@ export async function getPgClient() {
     await getDb();
   }
   return client!;
+}
+
+export async function closeDb() {
+  if (client && "end" in client && typeof client.end === "function") {
+    await client.end();
+  } else if (client && "close" in client && typeof client.close === "function") {
+    await client.close();
+  }
+  instance = undefined;
+  client = undefined;
 }

--- a/db/seed.ts
+++ b/db/seed.ts
@@ -1,4 +1,4 @@
-import { getDb } from "../api/queries/connection";
+import { closeDb, getDb } from "../api/queries/connection";
 import { categories, users, profiles, items, wallets } from "./schema";
 import { eq } from "drizzle-orm";
 
@@ -144,7 +144,11 @@ async function seed() {
   console.log("Seed complete");
 }
 
-seed().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+seed()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await closeDb();
+  });

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,13 +1,22 @@
 import "dotenv/config";
+import fs from "node:fs";
 import path from "node:path";
 import { defineConfig } from "drizzle-kit";
+
+const databaseUrl = process.env.DATABASE_URL || "./data/pglite";
+const isPglitePath = !databaseUrl.startsWith("postgres") && !databaseUrl.startsWith("postgresql");
+const resolvedDatabaseUrl = isPglitePath ? path.resolve(process.cwd(), databaseUrl) : databaseUrl;
+
+if (isPglitePath) {
+  fs.mkdirSync(path.dirname(resolvedDatabaseUrl), { recursive: true });
+}
 
 export default defineConfig({
   schema: "./db/schema.ts",
   out: "./db/migrations",
   dialect: "postgresql",
-  driver: "pglite",
+  ...(isPglitePath ? { driver: "pglite" as const } : {}),
   dbCredentials: {
-    url: path.resolve(process.cwd(), process.env.DATABASE_URL || "./data/pglite"),
+    url: resolvedDatabaseUrl,
   },
 });

--- a/render.yaml
+++ b/render.yaml
@@ -9,7 +9,7 @@ services:
     region: singapore
     branch: main
     buildCommand: npm ci && npm run build
-    startCommand: NODE_ENV=production node dist/boot.js
+    startCommand: bash scripts/start-prod.sh
     healthCheckPath: /api/health
     envVars:
       - key: NODE_VERSION


### PR DESCRIPTION
## Summary

This PR prepares the Render backend to connect to a real PostgreSQL database and become ready after deploy.

## Changes

- Use `bash scripts/start-prod.sh` as the Render start command so schema push and seed run before the API starts.
- Update Drizzle config to use PGlite only for local path databases and normal PostgreSQL config for `postgresql://...` URLs.
- Add a `closeDb()` helper so seed scripts can close PGlite/Postgres connections cleanly.
- Update `db/seed.ts` to close the database connection in `finally`.

## Validation

Local validation before publishing:

- `npm run db:push`
- `npm run check`
- `npm run lint`
- `npm run test`
- `npm run build`

## Deployment note

After merge, redeploy `qxwap-api` on Render and verify `https://qxwap-api.onrender.com/api/ready` returns `{"ok":true,"database":true}`. If it still returns 503, the Render service still needs a valid `DATABASE_URL` pointing to the real PostgreSQL database.