### PR TITLE
Make production seed command non-interactive

### DIFF
--- a/scripts/start-prod.sh
+++ b/scripts/start-prod.sh
@@ -29,7 +29,7 @@ pool.query('SELECT COUNT(*) FROM users').then(r => {
 
 if [ $? -ne 0 ]; then
   echo "[QXwap] Seeding database..."
-  npx tsx db/seed.ts
+  npx --yes tsx db/seed.ts
 fi
 
 # Start server


### PR DESCRIPTION
## Summary

Small production hardening change for the Render startup script.

## Change

- Replace `npx tsx db/seed.ts` with `npx --yes tsx db/seed.ts` so startup cannot block on an interactive npm prompt if `tsx` needs to be resolved at runtime.

## Why

The backend still reports `database:false` in production. The previous PR prepared real PostgreSQL startup; this removes one more possible startup blocker during seed.

## Validation

Local validation already passed in this workspace:

- `npm run check`
- `npm run test`
- `npm run build`