### PR TITLE
Expose production database readiness diagnostics

### DIFF
--- a/api/boot.ts
+++ b/api/boot.ts
@@ -16,6 +16,19 @@ const DB_HEALTH_TIMEOUT_MS = 3000;
 
 app.get("/api/health", (c) => c.json({ ok: true }));
 
+function databaseConfigStatus() {
+  return {
+    nodeEnv: process.env.NODE_ENV || "",
+    hasDatabaseUrl: env.hasDatabaseUrl,
+    databaseUrlType: env.hasDatabaseUrl
+      ? env.isPostgresDatabaseUrl
+        ? "postgres"
+        : "non-postgres"
+      : "missing",
+    frontendOrigin: process.env.FRONTEND_ORIGIN || "",
+  };
+}
+
 app.use(cors({
   origin: env.isProduction ? (process.env.FRONTEND_ORIGIN || "https://aswer1840.github.io") : "http://localhost:3000",
   credentials: true,
@@ -49,6 +62,15 @@ app.get("/uploads/*", async (c) => {
 
 app.get("/api/ready", async (c) => {
   try {
+    if (env.isProduction && (!env.hasDatabaseUrl || !env.isPostgresDatabaseUrl)) {
+      return c.json({
+        ok: false,
+        database: false,
+        message: "DATABASE_URL must be a PostgreSQL connection string in production",
+        config: databaseConfigStatus(),
+      }, 503);
+    }
+
     await Promise.race([
       (async () => {
         const db = await getDb();
@@ -58,10 +80,15 @@ app.get("/api/ready", async (c) => {
         setTimeout(() => reject(new Error("Database health check timed out")), DB_HEALTH_TIMEOUT_MS);
       }),
     ]);
-    return c.json({ ok: true, database: true });
+    return c.json({ ok: true, database: true, config: databaseConfigStatus() });
   } catch (error) {
     console.error("[health] readiness check failed", error);
-    return c.json({ ok: false, database: false, message: "Database is not ready" }, 503);
+    return c.json({
+      ok: false,
+      database: false,
+      message: error instanceof Error ? error.message : "Database is not ready",
+      config: databaseConfigStatus(),
+    }, 503);
   }
 });
 

--- a/api/lib/env.ts
+++ b/api/lib/env.ts
@@ -1,10 +1,16 @@
 import "dotenv/config";
 
+const databaseUrl = process.env.DATABASE_URL || "";
+const isProduction = process.env.NODE_ENV === "production";
+const isPostgresDatabaseUrl = databaseUrl.startsWith("postgres://") || databaseUrl.startsWith("postgresql://");
+
 export const env = {
   appId: process.env.APP_ID ?? "",
   appSecret: process.env.APP_SECRET ?? "",
-  isProduction: process.env.NODE_ENV === "production",
-  databaseUrl: process.env.DATABASE_URL || "./data/pglite",
+  isProduction,
+  databaseUrl: databaseUrl || "./data/pglite",
+  hasDatabaseUrl: Boolean(databaseUrl),
+  isPostgresDatabaseUrl,
   sessionSecret: process.env.SESSION_SECRET || "default-secret-change-me",
   port: parseInt(process.env.PORT || "10000"),
 };

--- a/api/queries/connection.ts
+++ b/api/queries/connection.ts
@@ -17,6 +17,10 @@ export async function getDb() {
     const dbUrl = env.databaseUrl;
     const isPglitePath = !dbUrl?.startsWith("postgres") && !dbUrl?.startsWith("postgresql");
 
+    if (env.isProduction && (!env.hasDatabaseUrl || isPglitePath)) {
+      throw new Error("DATABASE_URL must be set to a PostgreSQL connection string in production");
+    }
+
     if (env.isProduction && !isPglitePath) {
       // Production with real PostgreSQL
       if (!dbUrl) {


### PR DESCRIPTION
## Summary

Make production database failures actionable without exposing secrets.

## Changes

- Track whether `DATABASE_URL` is present and whether it looks like a PostgreSQL connection string.
- Prevent production from silently falling back to local PGlite when `DATABASE_URL` is missing or invalid.
- Return safe `/api/ready` diagnostics: `hasDatabaseUrl`, `databaseUrlType`, `nodeEnv`, and `frontendOrigin`.
- Preserve secret safety by never returning the actual `DATABASE_URL`.

## Validation

- `npm run check`
- `npm run test`
- `npm run build`

## Why

The real API currently returns `database:false` with no actionable reason. This will let us distinguish missing env, wrong env type, timeout, auth failure, or schema/connection issues from the public readiness endpoint.