### PR TITLE
Deploy current frontend to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,53 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: github-pages-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend for GitHub Pages
+        run: |
+          npx vite build --base=/QXwap/
+          node build-server.mjs
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const file = 'dist/public/index.html';
+          const apiBase = 'https://qxwap-api.onrender.com/api';
+          const html = fs.readFileSync(file, 'utf8').replaceAll('__API_BASE__', apiBase);
+          fs.writeFileSync(file, html);
+          NODE
+
+      - name: Keep GitHub Pages from running Jekyll
+        run: touch dist/public/.nojekyll
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: dist/public
+          force_orphan: false

--- a/index.html
+++ b/index.html
@@ -7,13 +7,13 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>QXwap</title>
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="%BASE_URL%manifest.json" />
     <script>
       // API_BASE can be injected at deploy time by replacing __API_BASE__
       // Default: "/api" (same-origin, works when frontend and backend share a domain)
       // For separate frontend hosting: set to "https://your-backend.com/api"
       window.API_BASE = window.API_BASE || "__API_BASE__";
-      if (window.API_BASE === "__API_BASE__") {
+      if (window.API_BASE.includes("__API" + "_BASE__")) {
         window.API_BASE = "/api"; // fallback for local dev
       }
     </script>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,18 +1,18 @@
 {
   "name": "QXwap",
   "short_name": "QXwap",
-  "start_url": "/",
+  "start_url": "/QXwap/",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#2563eb",
   "icons": [
     {
-      "src": "/icon-192.png",
+      "src": "/QXwap/icon-192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/icon-512.png",
+      "src": "/QXwap/icon-512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
## Summary
- Fix GitHub Pages base paths for built assets and manifest
- Keep deploy-time API base injection compatible with the production API
- Add a GitHub Actions workflow that builds the current Vite frontend and publishes `dist/public` to `gh-pages`

## Validation
- Local build with `npx vite build --base=/QXwap/` passed
- Built HTML points assets to `/QXwap/assets/...`
- Built frontend uses `https://qxwap-api.onrender.com/api` and tRPC `/trpc` endpoints
