### PR TITLE
Fix existing GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,15 +67,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build frontend
+      - name: Build frontend for GitHub Pages
         env:
           VITE_API_BASE: ${{ secrets.API_BASE_URL || 'https://qxwap-api.onrender.com/api' }}
-        run: npm run build
-
-      - name: Inject API base URL into index.html
         run: |
-          API_BASE="${{ secrets.API_BASE_URL || 'https://qxwap-api.onrender.com/api' }}"
-          bash scripts/inject-api-base.sh "$API_BASE" dist/public/index.html
+          npx vite build --base=/QXwap/
+          node build-server.mjs
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const file = 'dist/public/index.html';
+          const apiBase = process.env.VITE_API_BASE || 'https://qxwap-api.onrender.com/api';
+          const html = fs.readFileSync(file, 'utf8').replaceAll('__API_BASE__', apiBase);
+          fs.writeFileSync(file, html);
+          NODE
+          touch dist/public/.nojekyll
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
## Summary
- Update the existing `CI and Deploy` Pages job to build with `/QXwap/` as the Vite base
- Replace the deploy-time API injection shell script with a Node replacement so it works reliably in CI
- Keep `.nojekyll` in the published output

## Why
The newly added Pages workflow deployed correctly, but the existing `CI and Deploy` workflow ran afterward and overwrote `gh-pages` with root-relative `/assets/...` URLs.
