### PR TITLE
Fix critical launch blockers

### DIFF
--- a/api/boot.ts
+++ b/api/boot.ts
@@ -30,7 +30,7 @@ function databaseConfigStatus() {
 }
 
 app.use(cors({
-  origin: env.isProduction ? (process.env.FRONTEND_ORIGIN || "https://aswer1840.github.io") : "http://localhost:3000",
+  origin: env.isProduction ? (process.env.FRONTEND_ORIGIN || "https://aswer18400.github.io") : "http://localhost:3000",
   credentials: true,
   allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
   allowHeaders: ["Content-Type", "Authorization"],
@@ -98,6 +98,28 @@ app.route("/api/auth", authRoutes);
 import uploadRoutes from "./routes/upload";
 app.use("/api/upload", bodyLimit({ maxSize: 50 * 1024 * 1024 }));
 app.route("/api/upload", uploadRoutes);
+
+import restRoutes from "./routes/rest";
+app.route("/api", restRoutes);
+
+app.get("/api/events", () => {
+  const stream = new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+      controller.enqueue(encoder.encode("retry: 30000\n\n"));
+      controller.enqueue(encoder.encode(`event: ready\ndata: ${JSON.stringify({ ok: true })}\n\n`));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      "Connection": "keep-alive",
+    },
+  });
+});
 
 app.use("/api/trpc/*", async (c) => {
   return fetchRequestHandler({

--- a/api/routes/rest.ts
+++ b/api/routes/rest.ts
@@ -1,0 +1,197 @@
+import { Hono, type Context } from "hono";
+import { appRouter } from "../router";
+import { getSession, parseCookies } from "../lib/session";
+
+const rest = new Hono();
+
+type Caller = ReturnType<typeof appRouter.createCaller>;
+
+async function createCaller(c: Context): Promise<Caller> {
+  const cookies = parseCookies(c.req.header("cookie") || "");
+  const sid = cookies["sid"] || "";
+  const session = sid ? await getSession(sid) : null;
+  return appRouter.createCaller({
+    req: c.req.raw,
+    resHeaders: new Headers(),
+    userId: session?.userId || null,
+    email: session?.email || null,
+  });
+}
+
+async function readJson(c: Context) {
+  try {
+    return await c.req.json();
+  } catch {
+    return {};
+  }
+}
+
+function normalizeListQuery(c: Context) {
+  const q = c.req.query();
+  return {
+    q: q.q,
+    category: q.category,
+    dealType: q.dealType,
+    minPrice: q.minPrice,
+    maxPrice: q.maxPrice,
+    wantedTag: q.wantedTag,
+    ownerId: q.ownerId,
+    status: q.status,
+    condition: q.condition,
+    sort: q.sort,
+    limit: q.limit,
+    offset: q.offset,
+    openToOffers: q.openToOffers === "true" ? true : undefined,
+    following: q.following === "true" ? true : undefined,
+    fastResponder: q.fastResponder === "true" ? true : undefined,
+    featured: q.featured === "true" ? true : undefined,
+  };
+}
+
+function routeError(error: unknown) {
+  const message = error instanceof Error ? error.message : "Request failed";
+  const isUnauthorized = message.toLowerCase().includes("unauthorized") || message.includes("เข้าสู่ระบบ");
+  return {
+    body: { success: false, message, error: message },
+    status: isUnauthorized ? 401 : 400,
+  } as const;
+}
+
+rest.get("/items", async (c) => {
+  try {
+    const caller = await createCaller(c);
+    return c.json(await caller.item.list(normalizeListQuery(c)));
+  } catch (error) {
+    const err = routeError(error);
+    return c.json(err.body, err.status);
+  }
+});
+
+rest.post("/items", async (c) => {
+  try {
+    const caller = await createCaller(c);
+    return c.json(await caller.item.create(await readJson(c)));
+  } catch (error) {
+    const err = routeError(error);
+    return c.json(err.body, err.status);
+  }
+});
+
+rest.get("/items/:id", async (c) => {
+  try {
+    const caller = await createCaller(c);
+    const item = await caller.item.byId({ id: c.req.param("id") });
+    return item ? c.json(item) : c.json({ error: "Not found" }, 404);
+  } catch (error) {
+    const err = routeError(error);
+    return c.json(err.body, err.status);
+  }
+});
+
+async function updateItem(c: Context) {
+  try {
+    const caller = await createCaller(c);
+    return c.json(await caller.item.update({ id: c.req.param("id"), ...(await readJson(c)) }));
+  } catch (error) {
+    const err = routeError(error);
+    return c.json(err.body, err.status);
+  }
+}
+
+rest.put("/items/:id", updateItem);
+rest.patch("/items/:id", updateItem);
+
+rest.delete("/items/:id", async (c) => {
+  try {
+    const caller = await createCaller(c);
+    return c.json(await caller.item.delete({ id: c.req.param("id") }));
+  } catch (error) {
+    const err = routeError(error);
+    return c.json(err.body, err.status);
+  }
+});
+
+rest.get("/offers", async (c) => {
+  try {
+    const caller = await createCaller(c);
+    return c.json(await caller.offer.list());
+  } catch (error) {
+    const err = routeError(error);
+    return c.json(err.body, err.status);
+  }
+});
+
+rest.post("/offers", async (c) => {
+  try {
+    const caller = await createCaller(c);
+    return c.json(await caller.offer.create(await readJson(c)));
+  } catch (error) {
+    const err = routeError(error);
+    return c.json(err.body, err.status);
+  }
+});
+
+rest.get("/offers/:id", async (c) => {
+  try {
+    const caller = await createCaller(c);
+    const offer = await caller.offer.byId({ id: c.req.param("id") });
+    return offer ? c.json(offer) : c.json({ error: "Not found" }, 404);
+  } catch (error) {
+    const err = routeError(error);
+    return c.json(err.body, err.status);
+  }
+});
+
+for (const action of ["accept", "reject", "cancel", "confirm"] as const) {
+  rest.post(`/offers/:id/${action}`, async (c) => {
+    try {
+      const caller = await createCaller(c);
+      return c.json(await caller.offer[action]({ id: c.req.param("id") }));
+    } catch (error) {
+      const err = routeError(error);
+      return c.json(err.body, err.status);
+    }
+  });
+}
+
+rest.get("/wallet", async (c) => {
+  try {
+    const caller = await createCaller(c);
+    return c.json(await caller.wallet.get());
+  } catch (error) {
+    const err = routeError(error);
+    return c.json(err.body, err.status);
+  }
+});
+
+rest.get("/transactions", async (c) => {
+  try {
+    const caller = await createCaller(c);
+    return c.json(await caller.wallet.transactions());
+  } catch (error) {
+    const err = routeError(error);
+    return c.json(err.body, err.status);
+  }
+});
+
+rest.get("/notifications", async (c) => {
+  try {
+    const caller = await createCaller(c);
+    return c.json(await caller.notification.list());
+  } catch (error) {
+    const err = routeError(error);
+    return c.json(err.body, err.status);
+  }
+});
+
+rest.post("/notifications/read", async (c) => {
+  try {
+    const caller = await createCaller(c);
+    return c.json(await caller.notification.read(await readJson(c)));
+  } catch (error) {
+    const err = routeError(error);
+    return c.json(err.body, err.status);
+  }
+});
+
+export default rest;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route, useLocation, useNavigate } from 'react-router'
+import { Navigate, Routes, Route, useLocation } from 'react-router'
 import Feed from './pages/Feed'
 import Shop from './pages/Shop'
 import AddProduct from './pages/AddProduct'
@@ -12,47 +12,79 @@ import EditProfile from './pages/EditProfile'
 import Chat from './pages/Chat'
 import BottomNav from './components/layout/BottomNav'
 import { useAuth } from './hooks/useAuth'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 function Layout({ children }: { children: React.ReactNode }) {
   const location = useLocation()
   const hideNav = ['/login', '/item/', '/chat/'].some(p => location.pathname.startsWith(p))
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
+      <NetworkBanner />
       {children}
       {!hideNav && <BottomNav />}
     </div>
   )
 }
 
+function NetworkBanner() {
+  const [isOnline, setIsOnline] = useState(() => typeof navigator === 'undefined' ? true : navigator.onLine)
+
+  useEffect(() => {
+    const online = () => setIsOnline(true)
+    const offline = () => setIsOnline(false)
+    window.addEventListener('online', online)
+    window.addEventListener('offline', offline)
+    return () => {
+      window.removeEventListener('online', online)
+      window.removeEventListener('offline', offline)
+    }
+  }, [])
+
+  if (isOnline) return null
+
+  return (
+    <div className="fixed top-0 left-0 right-0 z-[80] bg-amber-500 px-4 py-2 text-center text-xs font-semibold text-white">
+      ออฟไลน์อยู่ บางข้อมูลอาจไม่โหลดจนกว่าจะเชื่อมต่ออีกครั้ง
+    </div>
+  )
+}
+
+function LoadingScreen() {
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center text-sm text-gray-400">
+      กำลังตรวจสอบบัญชี...
+    </div>
+  )
+}
+
+function ProtectedRoute({ children }: { children: React.ReactNode }) {
+  const { isLoading, user } = useAuth()
+  const location = useLocation()
+
+  if (isLoading) return <LoadingScreen />
+  if (!user) return <Navigate to="/login" state={{ from: location }} />
+
+  return children
+}
+
 export default function App() {
   const { isLoading, user } = useAuth()
   const location = useLocation()
-  const navigate = useNavigate()
-
-  useEffect(() => {
-    if (!isLoading && !user && location.pathname !== '/login') {
-      const protectedPaths = ['/add', '/inbox', '/profile', '/wallet', '/notifications', '/edit-profile']
-      if (protectedPaths.some(p => location.pathname.startsWith(p))) {
-        navigate('/login')
-      }
-    }
-  }, [isLoading, user, location.pathname, navigate])
 
   return (
     <Layout>
       <Routes>
         <Route path="/" element={<Feed />} />
         <Route path="/shop" element={<Shop />} />
-        <Route path="/add" element={<AddProduct />} />
-        <Route path="/inbox" element={<Inbox />} />
-        <Route path="/profile" element={<Profile />} />
-        <Route path="/login" element={<Login />} />
+        <Route path="/add" element={<ProtectedRoute><AddProduct /></ProtectedRoute>} />
+        <Route path="/inbox" element={<ProtectedRoute><Inbox /></ProtectedRoute>} />
+        <Route path="/profile" element={<ProtectedRoute><Profile /></ProtectedRoute>} />
+        <Route path="/login" element={!isLoading && user ? <Navigate to={(location.state as any)?.from?.pathname || '/'} replace /> : <Login />} />
         <Route path="/item/:id" element={<ItemDetail />} />
-        <Route path="/wallet" element={<Wallet />} />
-        <Route path="/notifications" element={<Notifications />} />
-        <Route path="/edit-profile" element={<EditProfile />} />
-        <Route path="/chat/:conversationId" element={<Chat />} />
+        <Route path="/wallet" element={<ProtectedRoute><Wallet /></ProtectedRoute>} />
+        <Route path="/notifications" element={<ProtectedRoute><Notifications /></ProtectedRoute>} />
+        <Route path="/edit-profile" element={<ProtectedRoute><EditProfile /></ProtectedRoute>} />
+        <Route path="/chat/:conversationId" element={<ProtectedRoute><Chat /></ProtectedRoute>} />
       </Routes>
     </Layout>
   )

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,13 +6,20 @@ import { TRPCProvider } from "@/providers/trpc"
 import { AuthProvider } from "@/hooks/useAuth"
 import App from './App.tsx'
 
+const routerBase = import.meta.env.BASE_URL === '/' ? undefined : import.meta.env.BASE_URL.replace(/\/$/, '')
+const assetBase = import.meta.env.BASE_URL === '/' ? '/' : import.meta.env.BASE_URL
+
+window.addEventListener('unhandledrejection', (event) => {
+  console.error('[QXwap] Unhandled promise rejection', event.reason)
+})
+
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('/sw.js').catch(() => {});
+  navigator.serviceWorker.register(`${assetBase}sw.js`).catch(() => {});
 }
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={routerBase}>
       <TRPCProvider>
         <AuthProvider>
           <App />

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useAuth } from '@/hooks/useAuth'
-import { useNavigate } from 'react-router'
+import { useLocation, useNavigate } from 'react-router'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Eye, EyeOff } from 'lucide-react'
@@ -10,15 +10,23 @@ export default function Login() {
   const [mode, setMode] = useState<'login' | 'signup'>('login')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
   const [showPw, setShowPw] = useState(false)
   const [error, setError] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const { login, signup } = useAuth()
   const navigate = useNavigate()
+  const location = useLocation()
   const utils = trpc.useContext()
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
+    if (mode === 'signup' && password !== confirmPassword) {
+      setError('รหัสผ่านยืนยันไม่ตรงกัน')
+      return
+    }
+    setIsSubmitting(true)
     try {
       if (mode === 'login') {
         await login(email, password)
@@ -27,22 +35,22 @@ export default function Login() {
       }
       utils.item.list.invalidate()
       utils.item.feed.invalidate()
-      navigate('/')
+      navigate((location.state as any)?.from?.pathname || '/', { replace: true })
     } catch (err: any) {
       setError(err.message || 'เกิดข้อผิดพลาด')
+    } finally {
+      setIsSubmitting(false)
     }
   }
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center p-6 bg-blue-600">
-      {/* Background pattern */}
       <div className="absolute inset-0 overflow-hidden">
         <div className="absolute -top-20 -right-20 w-72 h-72 bg-blue-500 rounded-full opacity-50" />
         <div className="absolute -bottom-20 -left-20 w-96 h-96 bg-blue-700 rounded-full opacity-30" />
       </div>
 
       <div className="relative z-10 w-full max-w-sm">
-        {/* Logo */}
         <div className="text-center mb-8">
           <div className="inline-flex items-center justify-center w-20 h-20 bg-white rounded-3xl shadow-xl mb-4">
             <span className="text-3xl font-black">
@@ -55,7 +63,6 @@ export default function Login() {
           <p className="text-blue-200 text-sm mt-1">ตลาดแลกเปลี่ยนสินค้า</p>
         </div>
 
-        {/* Card */}
         <div className="bg-white rounded-3xl shadow-2xl p-6">
           <h2 className="text-xl font-bold text-gray-900 mb-1">
             {mode === 'login' ? 'เข้าสู่ระบบ' : 'สมัครสมาชิก'}
@@ -84,6 +91,7 @@ export default function Login() {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   required
+                  minLength={6}
                   placeholder="••••••••"
                   className="h-12 rounded-xl bg-gray-50 border-gray-200 pr-10"
                 />
@@ -92,6 +100,20 @@ export default function Login() {
                 </button>
               </div>
             </div>
+            {mode === 'signup' && (
+              <div>
+                <label className="text-sm font-medium text-gray-700 mb-1.5 block">ยืนยันรหัสผ่าน</label>
+                <Input
+                  type={showPw ? 'text' : 'password'}
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  required
+                  minLength={6}
+                  placeholder="••••••••"
+                  className="h-12 rounded-xl bg-gray-50 border-gray-200"
+                />
+              </div>
+            )}
 
             {error && (
               <div className="p-3 bg-red-50 rounded-xl text-sm text-red-600">
@@ -102,8 +124,9 @@ export default function Login() {
             <Button
               type="submit"
               className="w-full h-12 rounded-xl bg-blue-600 hover:bg-blue-700 text-base font-bold shadow-lg shadow-blue-600/20"
+              disabled={isSubmitting}
             >
-              {mode === 'login' ? 'เข้าสู่ระบบ' : 'สมัครสมาชิก'}
+              {isSubmitting ? 'กำลังดำเนินการ...' : mode === 'login' ? 'เข้าสู่ระบบ' : 'สมัครสมาชิก'}
             </Button>
           </form>
 
@@ -112,14 +135,13 @@ export default function Login() {
             <button
               type="button"
               className="text-blue-600 font-semibold"
-              onClick={() => { setMode(mode === 'login' ? 'signup' : 'login'); setError('') }}
+              onClick={() => { setMode(mode === 'login' ? 'signup' : 'login'); setError(''); setConfirmPassword('') }}
             >
               {mode === 'login' ? 'สมัครเลย' : 'เข้าสู่ระบบ'}
             </button>
           </p>
         </div>
 
-        {/* Demo hint */}
         <p className="text-center text-xs text-blue-200 mt-6">
           Demo: demo@qxwap.com / demo1234
         </p>


### PR DESCRIPTION
## Summary
- Fix production CORS fallback origin typo for credentialed sessions
- Add REST compatibility endpoints for cached/legacy clients: `/api/items`, `/api/offers`, `/api/wallet`, `/api/transactions`, `/api/notifications`
- Add a lightweight `/api/events` SSE fallback with a long retry interval to avoid 404 retry storms
- Fix GitHub Pages router basename and service worker path for `/QXwap/`
- Replace post-render protected route redirects with guarded routes that wait for auth confirmation
- Harden login/signup loading, error state, return path, password length, and confirm password

## Validation
- Local `npm run check` passed
- Local `npm run lint` passed
- Local `npm run test` passed: 9 tests
- Local `npm run build` passed
