### PR TITLE
Return absolute URLs for uploaded images

### DIFF
--- a/api/routes/upload.ts
+++ b/api/routes/upload.ts
@@ -19,6 +19,7 @@ upload.post("/", async (c) => {
   // Use root-level uploads dir so it can be served by both dev and prod
   const uploadDir = path.join(process.cwd(), "uploads");
   await mkdir(uploadDir, { recursive: true });
+  const origin = new URL(c.req.url).origin;
   const urls: string[] = [];
   for (const file of files) {
     const ext = path.extname(file.name) || ".jpg";
@@ -26,7 +27,7 @@ upload.post("/", async (c) => {
     const buffer = Buffer.from(await file.arrayBuffer());
     const filePath = path.join(uploadDir, name);
     await writeFile(filePath, buffer);
-    urls.push(`/uploads/${name}`);
+    urls.push(`${origin}/uploads/${name}`);
   }
   return c.json({ urls });
 });

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -10,6 +10,14 @@ function uploadUrl() {
   return `${resolveApiBase()}/upload`;
 }
 
+function apiOrigin() {
+  return new URL(resolveApiBase(), window.location.origin).origin;
+}
+
+function normalizeUploadUrl(url: string) {
+  return new URL(url, apiOrigin()).toString();
+}
+
 function uploadErrorMessage(payload: UploadResponse | null) {
   return payload?.message || payload?.error || "อัปโหลดรูปไม่สำเร็จ";
 }
@@ -42,5 +50,5 @@ export async function uploadImages(files: FileList | File[]) {
     throw new Error(uploadErrorMessage(payload));
   }
 
-  return payload.urls || [];
+  return (payload.urls || []).map(normalizeUploadUrl);
 }


### PR DESCRIPTION
## Summary
- return absolute `/uploads` URLs from the upload API
- normalize upload URLs in the frontend helper so older relative upload responses still render from the API origin

## Verified locally
- `npm run check`
- `npm run lint` (passes with warnings)
- `npm run test`
- `npm run build`

## Why
Authenticated upload smoke testing showed the API returned `/uploads/...`; if stored by the GitHub Pages frontend, images would resolve against `aswer18400.github.io` instead of the Render API host.