### PR TITLE
Force HTTPS for production upload URLs

### DIFF
--- a/api/routes/upload.ts
+++ b/api/routes/upload.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { writeFile } from "node:fs/promises";
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
+import { env } from "../lib/env";
 
 const upload = new Hono();
 
@@ -19,7 +20,12 @@ upload.post("/", async (c) => {
   // Use root-level uploads dir so it can be served by both dev and prod
   const uploadDir = path.join(process.cwd(), "uploads");
   await mkdir(uploadDir, { recursive: true });
-  const origin = new URL(c.req.url).origin;
+  const requestUrl = new URL(c.req.url);
+  const forwardedHost = c.req.header("x-forwarded-host")?.split(",")[0]?.trim();
+  const forwardedProto = c.req.header("x-forwarded-proto")?.split(",")[0]?.trim();
+  const host = forwardedHost || c.req.header("host") || requestUrl.host;
+  const proto = env.isProduction ? "https" : forwardedProto || requestUrl.protocol.replace(":", "");
+  const origin = `${proto}://${host}`;
   const urls: string[] = [];
   for (const file of files) {
     const ext = path.extname(file.name) || ".jpg";


### PR DESCRIPTION
## Summary
- build upload origins from forwarded host/proto headers
- force HTTPS in production so Render upload URLs are stored as `https://...`

## Verified locally
- `npm run check`
- `npm run test`
- `npm run build`

## Why
Render exposed the request URL to Hono as `http://...`, so upload smoke tests returned `http://qxwap-api.onrender.com/uploads/...`. This keeps production image URLs clean and secure.