### PR TITLE
fix: add rootDir to render.yaml to ensure backend API runs correctly

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,6 +2,7 @@ services:
   - type: web
     name: qxwap-api
     runtime: node
+    rootDir: apps/api
     buildCommand: corepack enable && corepack prepare pnpm@9.15.4 --activate && pnpm install --frozen-lockfile && pnpm --filter @workspace/api-server build
     startCommand: pnpm --filter @workspace/api-server start
     healthCheckPath: /api/health


### PR DESCRIPTION
Render was serving frontend HTML instead of backend API. Adding rootDir: apps/api to render.yaml should fix this by telling Render to use the correct root directory for the service.