### PR TITLE
fix: adjust render.yaml build command to build all packages from root

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,8 +2,7 @@ services:
   - type: web
     name: qxwap-api
     runtime: node
-    rootDir: apps/api
-    buildCommand: corepack enable && corepack prepare pnpm@9.15.4 --activate && pnpm install --frozen-lockfile && pnpm --filter @workspace/api-server build
+    buildCommand: corepack enable && corepack prepare pnpm@9.15.4 --activate && pnpm install --frozen-lockfile && pnpm run build
     startCommand: pnpm --filter @workspace/api-server start
     healthCheckPath: /api/health
     envVars:


### PR DESCRIPTION
Previous rootDir approach didn't work. This removes rootDir and adjusts buildCommand to build all packages from root, which should allow Render to properly build and run the backend API.