### PR TITLE
fix: make render.yaml more explicit - use direct node command to start API server

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,8 +2,9 @@ services:
   - type: web
     name: qxwap-api
     runtime: node
+    rootDir: .
     buildCommand: corepack enable && corepack prepare pnpm@9.15.4 --activate && pnpm install --frozen-lockfile && pnpm run build
-    startCommand: pnpm --filter @workspace/api-server start
+    startCommand: cd apps/api && node dist/src/server.js
     healthCheckPath: /api/health
     envVars:
       - key: NODE_ENV


### PR DESCRIPTION
Render was still serving frontend. This change makes render.yaml more explicit by:\n1. Adding rootDir: . to clarify the root directory\n2. Changing startCommand to directly run 'cd apps/api && node dist/src/server.js' instead of using pnpm filter\n\nThis should force Render to run the backend API server instead of frontend.