### PR TITLE
fix: rewrite render.yaml with explicit multi-line commands and PORT env var

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,13 +2,22 @@ services:
   - type: web
     name: qxwap-api
     runtime: node
-    rootDir: .
-    buildCommand: corepack enable && corepack prepare pnpm@9.15.4 --activate && pnpm install --frozen-lockfile && pnpm run build
-    startCommand: cd apps/api && node dist/src/server.js
+    plan: standard
+    buildCommand: |
+      corepack enable
+      corepack prepare pnpm@9.15.4 --activate
+      pnpm install --frozen-lockfile
+      pnpm run build
+    startCommand: |
+      cd apps/api
+      node dist/src/server.js
     healthCheckPath: /api/health
+    healthCheckTimeout: 30
     envVars:
       - key: NODE_ENV
         value: production
+      - key: PORT
+        value: "3000"
       - key: DATABASE_URL
         sync: false
       - key: SESSION_SECRET
@@ -21,6 +30,3 @@ services:
         sync: false
       - key: STORAGE_BUCKET
         value: qxwap
-      # Render auto-injects RENDER_GIT_COMMIT and RENDER_GIT_BRANCH at build
-      # time. The API reads them at boot and exposes them at /api/version,
-      # so `curl <prod>/api/version` confirms which commit is actually live.


### PR DESCRIPTION
Final attempt to fix Render deployment. This version:\n1. Uses explicit multi-line commands for clarity\n2. Adds PORT=3000 env var explicitly\n3. Adds healthCheckTimeout=30\n4. Adds plan: standard\n\nThis should force Render to recognize and use the correct build/start commands.