### PR TITLE
fix: install dev dependencies during Render API build

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@ services:
     plan: standard
     buildCommand: |
       corepack prepare pnpm@9.15.4 --activate
-      pnpm install --frozen-lockfile
+      pnpm install --frozen-lockfile --prod=false
       pnpm --filter @workspace/api-server build
     startCommand: |
       pnpm --filter @workspace/api-server start


### PR DESCRIPTION
## Summary

- Add `--prod=false` to the Render install step so TypeScript build gets dev dependencies such as `@types/node` and `vitest` types even when `NODE_ENV=production`.

## Why

Render deploy `dep-d82bvs3bc2fs73c8q5fg` got past corepack, then failed with:

```text
devDependencies: skipped because NODE_ENV is set to production
error TS2688: Cannot find type definition file for 'node'.
error TS2688: Cannot find type definition file for 'vitest'.
```

## Verification

Ran locally:

```bash
corepack prepare pnpm@9.15.4 --activate && pnpm install --frozen-lockfile --prod=false && pnpm --filter @workspace/api-server build
```

Result: pass.

## After merge

Render Manual Deploy from latest `main`, then verify:

```bash
curl https://qxwap-api.onrender.com/api/health
curl https://qxwap-api.onrender.com/api/version
```