### PR TITLE
fix: restore session cookies behind Render proxy

### DIFF
--- a/AI_START_HERE.md
+++ b/AI_START_HERE.md
@@ -1,5 +1,13 @@
 # QXwap AI Start Here
 
+## Latest Status (2026-05-17 14:43 +07)
+
+- Render API is live on the monorepo backend at commit `1ab25c7aebf3a6d72301d36ff3be5abba916ca59`.
+- Production health/version verified: `/api/health` returns QXwap API + database connected, and `/api/version` returns commit `1ab25c7...`.
+- Production auth currently does not emit `Set-Cookie`; `pnpm smoke:api` fails at upload with 401 after signup.
+- Current patch fixes Render session cookies by trusting the production proxy and setting express-session `proxy: true`; smoke scripts now parse `qxwap.sid`/`connect.sid` cookies robustly.
+- After merge/deploy, rerun `curl -i /api/auth/signup` and confirm `Set-Cookie: qxwap.sid=...`, then rerun `API_BASE_URL=https://qxwap-api.onrender.com/api pnpm smoke:api`.
+
 Use this file as the low-token entrypoint for any AI/dev continuing QXwap.
 
 ## Rule

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -55,6 +55,7 @@ app.use(
   session({
     name: "qxwap.sid",
     secret: process.env.SESSION_SECRET || "dev-qxwap-secret",
+    proxy: process.env.NODE_ENV === "production",
     resave: false,
     saveUninitialized: false,
     store: new DbSessionStore(),

--- a/scripts/qxwap-api-smoke.mjs
+++ b/scripts/qxwap-api-smoke.mjs
@@ -48,6 +48,14 @@ async function getJson(path) {
 class ApiAgent {
   cookie = "";
 
+  captureCookie(headers) {
+    const headerList = typeof headers.getSetCookie === "function" ? headers.getSetCookie() : [headers.get("set-cookie")].filter(Boolean);
+    for (const rawCookie of headerList) {
+      const match = String(rawCookie).match(/(?:^|,\s*)(qxwap\.sid=[^;]+|connect\.sid=[^;]+)/);
+      if (match) this.cookie = match[1];
+    }
+  }
+
   async request(path, init = {}) {
     const headers = new Headers(init.headers || {});
     if (this.cookie) headers.set("cookie", this.cookie);
@@ -55,8 +63,7 @@ class ApiAgent {
       headers.set("content-type", "application/json");
     }
     const response = await fetch(`${apiBase}${path}`, { ...init, headers });
-    const setCookie = response.headers.get("set-cookie");
-    if (setCookie) this.cookie = setCookie.split(",").map((part) => part.split(";")[0]).join("; ");
+    this.captureCookie(response.headers);
     return readJson(response, `${init.method || "GET"} ${path}`);
   }
 


### PR DESCRIPTION
## Summary
- Set `express-session` `proxy: true` in production so secure cookies are emitted behind Render's TLS proxy.
- Make the API smoke script parse the production cookie name (`qxwap.sid`) robustly.
- Update `AI_START_HERE.md` with the current Render/production smoke status.

## Verification
- `pnpm --filter @workspace/api-server test`
- `pnpm --filter @workspace/api-server build`
- Production check before this patch: `/api/health` and `/api/version` are live, but `/auth/signup` does not emit `Set-Cookie` and `pnpm smoke:api` fails at upload with 401.

## Follow-up after deploy
- `curl -i https://qxwap-api.onrender.com/api/auth/signup ...` should include `Set-Cookie: qxwap.sid=...`.
- `API_BASE_URL=https://qxwap-api.onrender.com/api pnpm smoke:api` should pass.