### PR TITLE
fix: make notification read query Supabase-safe

### DIFF
--- a/AI_START_HERE.md
+++ b/AI_START_HERE.md
@@ -1,12 +1,20 @@
 # QXwap AI Start Here
 
-## Latest Status (2026-05-17 14:43 +07)
+## Latest Status (2026-05-17 14:56 +07)
 
-- Render API is live on the monorepo backend at commit `1ab25c7aebf3a6d72301d36ff3be5abba916ca59`.
-- Production health/version verified: `/api/health` returns QXwap API + database connected, and `/api/version` returns commit `1ab25c7...`.
-- Production auth currently does not emit `Set-Cookie`; `pnpm smoke:api` fails at upload with 401 after signup.
-- Current patch fixes Render session cookies by trusting the production proxy and setting express-session `proxy: true`; smoke scripts now parse `qxwap.sid`/`connect.sid` cookies robustly.
-- After merge/deploy, rerun `curl -i /api/auth/signup` and confirm `Set-Cookie: qxwap.sid=...`, then rerun `API_BASE_URL=https://qxwap-api.onrender.com/api pnpm smoke:api`.
+- Render API is live on the monorepo backend and was verified on commit `4977e90cc175cc646014b80bca2874b645698ed4`.
+- PR #131 fixed production session cookies behind Render:
+  - `POST https://qxwap-api.onrender.com/api/auth/signup` now returns `Set-Cookie: qxwap.sid=...; HttpOnly; Secure; SameSite=None`.
+  - `API_BASE_URL=https://qxwap-api.onrender.com/api pnpm smoke:api` passed.
+- Full production smoke was run next and found one remaining backend bug:
+  - `/api/notifications/read` returns 500 on Supabase with `operator does not exist: text = uuid`.
+  - Cause: the query casts `$2::uuid` even though production `notifications.id` is TEXT.
+- Current PR/patch fixes `/api/notifications/read` by branching in app code:
+  - no id -> `UPDATE notifications SET read_at=now() WHERE user_id=$1`
+  - with id -> `UPDATE notifications SET read_at=now() WHERE user_id=$1 AND id=$2`
+- After this patch deploys, rerun:
+  - `API_BASE_URL=https://qxwap-api.onrender.com/api node scripts/qxwap-full-smoke.mjs`
+  - Expected: all assertions pass.
 
 Use this file as the low-token entrypoint for any AI/dev continuing QXwap.
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -520,7 +520,19 @@ app.post("/api/wallet/deposit", requireAuth, asyncRoute(async (req, res) => {
 }));
 
 app.get("/api/notifications", requireAuth, asyncRoute(async (req, res) => res.json({ notifications: (await q("SELECT * FROM notifications WHERE user_id=$1 ORDER BY created_at DESC", [req.session.userId])).rows })));
-app.post("/api/notifications/read", requireAuth, asyncRoute(async (req, res) => { await q("UPDATE notifications SET read_at=now() WHERE user_id=$1 AND ($2::uuid IS NULL OR id=$2)", [req.session.userId, req.body.id || null]); res.json({ ok: true }); }));
+app.post("/api/notifications/read", requireAuth, asyncRoute(async (req, res) => {
+  // Branch in app code so the query is dialect-agnostic. The earlier
+  // `($2::uuid IS NULL OR id=$2)` pattern relied on id being UUID, which
+  // works on PGlite but throws "operator does not exist: text = uuid" on
+  // production Supabase where id is TEXT.
+  const targetId = req.body?.id;
+  if (targetId) {
+    await q("UPDATE notifications SET read_at=now() WHERE user_id=$1 AND id=$2", [req.session.userId, String(targetId)]);
+  } else {
+    await q("UPDATE notifications SET read_at=now() WHERE user_id=$1", [req.session.userId]);
+  }
+  res.json({ ok: true });
+}));
 app.get("/api/events", requireAuth, (req, res) => {
   res.setHeader("Content-Type", "text/event-stream");
   res.setHeader("Cache-Control", "no-cache, no-transform");


### PR DESCRIPTION
## Summary
- Fix `/api/notifications/read` on Supabase by removing the `$2::uuid` query pattern.
- Branch in app code for mark-all vs mark-one so production text ids do not compare against uuid parameters.
- Update `AI_START_HERE.md` with the latest production smoke status.

## Verification
- `pnpm --filter @workspace/api-server test` passed locally in the working tree.
- `pnpm --filter @workspace/api-server build` passed locally in the working tree.
- Production full smoke before this patch failed only at `mark-all-read` and `mark-one-read` with `operator does not exist: text = uuid`.