### PR TITLE
fix: reduce guest feed auth overlay

### DIFF
--- a/AI_START_HERE.md
+++ b/AI_START_HERE.md
@@ -1,6 +1,6 @@
 # QXwap AI Start Here
 
-## Latest Status (2026-05-17 14:57 +07)
+## Latest Status (2026-05-17 15:02 +07)
 
 - Render API is live on the monorepo backend and now runs commit `0c14e8f8836ced3cb39606c1bcbe127ada97c2a9`.
 - PR #131 fixed production session cookies behind Render:
@@ -13,9 +13,17 @@
 - Full production smoke passed:
   - `API_BASE_URL=https://qxwap-api.onrender.com/api node scripts/qxwap-full-smoke.mjs` -> 38 assertions, failed 0.
   - Covered health/version, signup sessions, owner/non-owner permissions, search/filter, Supabase image upload, profile photo persistence, no-item offer flow, shipment start, notifications mark-read, and owner delete cleanup.
+- Frontend production API base verified:
+  - `https://aswer18400.github.io/QXwap/` serves `window.API_BASE = "https://qxwap-api.onrender.com/api"`.
+  - `API_BASE_URL=https://qxwap-api.onrender.com/api pnpm preflight:frontend --health` -> passed.
+- Frontend UI patch in progress:
+  - Guest `AuthNudge` bottom layer was reduced and blur removed so it no longer visually washes out the lower Feed.
+  - Local verification after this patch: `pnpm run typecheck` passed and `PORT=4173 BASE_PATH=/ pnpm --filter @workspace/web-app build` passed.
+- Frontend production gap:
+  - `https://aswer18400.github.io/QXwap/status.html` currently returns GitHub Pages 404. Main app URL works, but status page is missing from deployed Pages output.
 - Next priority:
-  - Verify GitHub Pages frontend API base points to `https://qxwap-api.onrender.com/api`.
-  - Then continue mobile Feed UI/product-card fixes against the now-working production backend.
+  - Continue mobile Feed UI/product-card fixes against the now-working production backend.
+  - Restore/deploy `status.html` if this page is still required for launch monitoring.
 
 Use this file as the low-token entrypoint for any AI/dev continuing QXwap.
 

--- a/apps/web/src/styles/auth.css
+++ b/apps/web/src/styles/auth.css
@@ -4,19 +4,13 @@
   bottom: calc(var(--qx-nav-height) + var(--qx-layout-safe-bottom));
   transform: translateX(-50%);
   width: min(var(--qx-layout-mobile-width), 100vw);
-  min-height: min(20dvh, 168px);
+  min-height: 108px;
   z-index: 9;
   display: flex;
   align-items: end;
   justify-content: center;
-  padding: 40px 14px 12px;
-  background: linear-gradient(
-    180deg,
-    rgba(251, 252, 255, 0) 0%,
-    rgba(251, 252, 255, 0.86) 44%,
-    rgba(251, 252, 255, 0.98) 100%
-  );
-  backdrop-filter: blur(8px);
+  padding: 10px 14px 12px;
+  background: transparent;
   pointer-events: none;
 }
 
@@ -25,8 +19,8 @@
   min-width: 0;
   max-width: 492px;
   border: 1px solid color-mix(in srgb, var(--qx-color-border) 82%, transparent);
-  border-radius: 24px;
-  background: color-mix(in srgb, var(--qx-color-surface) 94%, transparent);
+  border-radius: 22px;
+  background: color-mix(in srgb, var(--qx-color-surface) 98%, transparent);
   box-shadow: var(--qx-shadow-nav);
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Reduce the guest login bottom nudge height on Feed.
- Remove the blur/gradient layer that visually washed out the lower Feed cards.
- Update `AI_START_HERE.md` with backend production smoke pass, frontend API-base verification, and the remaining status-page gap.

## Verification
- `pnpm run typecheck` passed in the local workspace.
- `PORT=4173 BASE_PATH=/ pnpm --filter @workspace/web-app build` passed in the local workspace.
- `API_BASE_URL=https://qxwap-api.onrender.com/api pnpm preflight:frontend --health` passed.
- Local Feed loaded seeded product cards at `http://localhost:5173/` with local API running.