### PR TITLE
Adjust AiFeed layout for mobile 390px

### DIFF
--- a/apps/web/src/screens/AiFeed.tsx
+++ b/apps/web/src/screens/AiFeed.tsx
@@ -54,7 +54,7 @@ export function AiFeed({
       ];
 
   return (
-    <section className="screen ai-feed">
+    <section className="screen ai-feed mx-auto w-full max-w-[390px]">
       <FollowRail
         people={people}
         selectedPersonId={selectedPersonId}


### PR DESCRIPTION
Only changes apps/web/src/screens/AiFeed.tsx to constrain the Feed layout for mobile 390px testing.

Acceptance criteria:
- Draft PR only
- Changed files: apps/web/src/screens/AiFeed.tsx
- No README.md changes
- No src/rateLimitMonitor.ts changes
- Do not merge until UI is tested at 390px