### PR TITLE
Allow Cloudflare Tunnel host for local mobile testing

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
   plugins: [react()],
   base: process.env.BASE_PATH || "/",
   server: {
+    host: "0.0.0.0",
+    allowedHosts: [".trycloudflare.com"],
     proxy: {
       "/api": {
         target: "http://localhost:8787",
@@ -17,4 +19,3 @@ export default defineConfig({
     }
   }
 });
-


### PR DESCRIPTION
Allows trycloudflare.com hosts in the Vite dev server so the local QXwap web app can be tested on mobile through Cloudflare Tunnel.

Changes:
- Set Vite dev server host to 0.0.0.0
- Allow .trycloudflare.com hosts

Do not merge until verified on a mobile browser through Cloudflare Tunnel.